### PR TITLE
Register Media extension listeners for Edge and Configuration workflows (resolves #2 #3)

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21'        
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20'
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.12.0"
     }
 }

--- a/code/edgemedia/build.gradle
+++ b/code/edgemedia/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
     id "jacoco"
     id 'com.diffplug.spotless'
-
+    id 'kotlin-android'
 }
 
 apply from: 'release.gradle'

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessor.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessor.kt
@@ -9,7 +9,7 @@
   governing permissions and limitations under the License.
 */
 
-package com.adobe.marketing.mobile.media.internal
+package com.adobe.marketing.mobile.edge.media.internal
 
 internal class MediaEventProcessor {
     private val SOURCE_TAG = "MediaEventProcessor"

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessor.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessor.kt
@@ -1,0 +1,28 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.media.internal
+
+internal class MediaEventProcessor {
+    private val SOURCE_TAG = "MediaEventProcessor"
+
+    fun notifyBackendSessionId(requestEventId: String, backendSessionId: String?) {
+    }
+
+    fun notifyErrorResponse(requestEventId: String, data: Map<String, Any>) {
+    }
+
+    fun updateMediaState(stateData: Map<String, Any>) {
+    }
+
+    fun abortAllSessions() {
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -81,7 +81,7 @@ public class MediaExtension extends Extension {
                         this::handleMediaEdgeSessionDetails);
         getApi().registerEventListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE,
                         this::handleEdgeErrorResponse);
         getApi().registerEventListener(
                         EventType.CONFIGURATION,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -227,6 +227,7 @@ public class MediaExtension extends Extension {
                 SOURCE_TAG,
                 "handleResetIdentities - Clearing all tracking sessions.");
 
+        mediaEventProcessor.abortAllSessions();
         trackers.clear();
     }
 }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -35,8 +35,7 @@ public class MediaExtension extends Extension {
 
     private static final String SOURCE_TAG = "MediaExtension";
 
-    @VisibleForTesting
-    protected final Map<String, MediaTrackerInterface> trackers;
+    @VisibleForTesting protected final Map<String, MediaTrackerInterface> trackers;
 
     @VisibleForTesting protected MediaEventProcessor mediaEventProcessor;
 
@@ -91,7 +90,9 @@ public class MediaExtension extends Extension {
     }
 
     /**
-     * Handler for the session ID returned by the media backend response dispatched by the Edge extension.
+     * Handler for the session ID returned by the media backend response dispatched by the Edge
+     * extension.
+     *
      * @param event the Edge new media analytics session event containing the backend session ID
      */
     void handleMediaEdgeSessionDetails(@NonNull final Event event) {
@@ -121,6 +122,7 @@ public class MediaExtension extends Extension {
 
     /**
      * Handler for error responses dispatched by the Edge extension.
+     *
      * @param event the Edge error response content event
      */
     void handleEdgeErrorResponse(@NonNull final Event event) {
@@ -135,11 +137,18 @@ public class MediaExtension extends Extension {
     }
 
     /**
-     * Handler for configuration response events by notifying current sessions of the configuration change.
+     * Handler for configuration response events by notifying current sessions of the configuration
+     * change.
+     *
      * @param event the configuration response event.
      */
     void handleConfigurationResponseEvent(@NonNull final Event event) {
-        SharedStateResult configStateResult = getApi().getSharedState(MediaInternalConstants.Configuration.SHARED_STATE_NAME, event,false, SharedStateResolution.ANY);
+        SharedStateResult configStateResult =
+                getApi().getSharedState(
+                                MediaInternalConstants.Configuration.SHARED_STATE_NAME,
+                                event,
+                                false,
+                                SharedStateResolution.ANY);
         if (configStateResult != null && !MapUtils.isNullOrEmpty(configStateResult.getValue())) {
             mediaEventProcessor.updateMediaState(configStateResult.getValue());
         }
@@ -147,6 +156,7 @@ public class MediaExtension extends Extension {
 
     /**
      * Handler for media tracker creation requests.
+     *
      * @param event the Edge Media request tracker event
      */
     void handleMediaTrackerRequestEvent(@NonNull final Event event) {
@@ -184,6 +194,7 @@ public class MediaExtension extends Extension {
 
     /**
      * Handler for media track requests.
+     *
      * @param event the Edge Media track media event
      */
     void handleMediaTrackEvent(@NonNull final Event event) {
@@ -218,6 +229,7 @@ public class MediaExtension extends Extension {
 
     /**
      * Handler for reset identities requests. Clears all media trackers and sessions.
+     *
      * @param event the identity request reset event
      */
     void handleResetIdentities(@NonNull final Event event) {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -35,14 +35,13 @@ public class MediaExtension extends Extension {
 
     private static final String SOURCE_TAG = "MediaExtension";
 
-    final Map<String, MediaTrackerInterface> trackers;
-    MediaState mediaState;
+    @VisibleForTesting
+    protected final Map<String, MediaTrackerInterface> trackers;
 
     @VisibleForTesting protected MediaEventProcessor mediaEventProcessor;
 
     MediaExtension(final ExtensionApi extensionApi) {
         super(extensionApi);
-        mediaState = new MediaState();
         trackers = new HashMap<>();
         mediaEventProcessor = new MediaEventProcessor();
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -22,7 +22,6 @@ import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.Media;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
-import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.MapUtils;
@@ -50,7 +49,7 @@ public class MediaExtension extends Extension {
 
     @NonNull @Override
     protected String getName() {
-        return MediaInternalConstants.Media.SHARED_STATE_NAME;
+        return MediaInternalConstants.EXTENSION_NAME;
     }
 
     @Nullable @Override

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -91,6 +91,10 @@ public class MediaExtension extends Extension {
                         this::handleConfigurationResponseEvent);
     }
 
+    /**
+     * Handler for the session ID returned by the media backend response dispatched by the Edge extension.
+     * @param event the Edge new media analytics session event containing the backend session ID
+     */
     void handleMediaEdgeSessionDetails(@NonNull final Event event) {
         String requestEventId =
                 DataReader.optString(
@@ -100,7 +104,7 @@ public class MediaExtension extends Extension {
         }
 
         String backendSessionId =
-                null; // session id is null if either 'payload' or 'sessionid' is null
+                null; // session id is null if either 'payload' or 'sessionId' is null
         List<Map<String, Object>> payload =
                 DataReader.optTypedListOfMap(
                         Object.class,
@@ -116,6 +120,10 @@ public class MediaExtension extends Extension {
         mediaEventProcessor.notifyBackendSessionId(requestEventId, backendSessionId);
     }
 
+    /**
+     * Handler for error responses dispatched by the Edge extension.
+     * @param event the Edge error response content event
+     */
     void handleEdgeErrorResponse(@NonNull final Event event) {
         String requestEventId =
                 DataReader.optString(
@@ -128,7 +136,7 @@ public class MediaExtension extends Extension {
     }
 
     /**
-     * Handles configuration response events by notifying current sessions of the configuration change.
+     * Handler for configuration response events by notifying current sessions of the configuration change.
      * @param event the configuration response event.
      */
     void handleConfigurationResponseEvent(@NonNull final Event event) {
@@ -138,6 +146,10 @@ public class MediaExtension extends Extension {
         }
     }
 
+    /**
+     * Handler for media tracker creation requests.
+     * @param event the Edge Media request tracker event
+     */
     void handleMediaTrackerRequestEvent(@NonNull final Event event) {
         String trackerId =
                 DataReader.optString(
@@ -171,6 +183,10 @@ public class MediaExtension extends Extension {
         // trackers.put(trackerId, new MediaEventTracker(mediaEventProcessor, trackerConfig));
     }
 
+    /**
+     * Handler for media track requests.
+     * @param event the Edge Media track media event
+     */
     void handleMediaTrackEvent(@NonNull final Event event) {
         String trackerId =
                 DataReader.optString(
@@ -201,6 +217,10 @@ public class MediaExtension extends Extension {
         tracker.track(event);
     }
 
+    /**
+     * Handler for reset identities requests. Clears all media trackers and sessions.
+     * @param event the identity request reset event
+     */
     void handleResetIdentities(@NonNull final Event event) {
         Log.debug(
                 MediaInternalConstants.LOG_TAG,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -32,6 +32,7 @@ final class MediaInternalConstants {
     }
 
     static final class Configuration {
+        static final String SHARED_STATE_NAME = "com.adobe.module.configuration";
         static final String MEDIA_CHANNEL = "media.channel";
         static final String MEDIA_PLAYER_NAME = "media.playerName";
         static final String MEDIA_APP_VERSION = "media.appVersion";

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -24,6 +24,9 @@ final class MediaInternalConstants {
         static final String EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventsource.media.trackmedia";
         static final String EVENT_NAME_SESSION_CREATED =
                 "com.adobe.eventsource.media.sessioncreated";
+        static final String EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session";
+        static final String EVENT_SOURCE_EDGE_ERROR_RESOURCE =
+                "com.adobe.eventSource.errorResponseContent";
 
         private Media() {}
     }
@@ -34,6 +37,14 @@ final class MediaInternalConstants {
         static final String MEDIA_APP_VERSION = "media.appVersion";
 
         private Configuration() {}
+    }
+
+    static final class Edge {
+        static final String REQUEST_EVENT_ID = "requestEventId";
+        static final String PAYLOAD = "payload";
+        static final String SESSION_ID = "sessionId";
+
+        private Edge() {}
     }
 
     static final class EventDataKeys {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -13,12 +13,12 @@ package com.adobe.marketing.mobile.edge.media.internal;
 
 final class MediaInternalConstants {
     static final String LOG_TAG = "Media";
+    static final String EXTENSION_NAME = "com.adobe.edge.media";
     static final String FRIENDLY_NAME = "Media";
 
     private MediaInternalConstants() {}
 
     static final class Media {
-        static final String SHARED_STATE_NAME = "com.adobe.module.media";
         static final String EVENT_SOURCE_TRACKER_REQUEST =
                 "com.adobe.eventsource.media.requesttracker";
         static final String EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventsource.media.trackmedia";

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -25,7 +25,7 @@ final class MediaInternalConstants {
         static final String EVENT_NAME_SESSION_CREATED =
                 "com.adobe.eventsource.media.sessioncreated";
         static final String EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session";
-        static final String EVENT_SOURCE_EDGE_ERROR_RESOURCE =
+        static final String EVENT_SOURCE_EDGE_ERROR_RESPONSE =
                 "com.adobe.eventSource.errorResponseContent";
 
         private Media() {}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -26,25 +26,19 @@ import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionEventListener;
-<<<<<<< HEAD:code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
-<<<<<<< HEAD:code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
-=======
-import java.util.ArrayList;
->>>>>>> 259e920 (Add listeners for Edge events):code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaExtensionTests.java
-=======
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
 
-import java.util.ArrayList;
-import java.util.Collections;
->>>>>>> 4e2bfc9 (Register listener for Configuration Response Content events):code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaExtensionTests.java
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MediaExtensionTests {
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -24,6 +24,10 @@ import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionEventListener;
+<<<<<<< HEAD:code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+=======
+import java.util.ArrayList;
+>>>>>>> 259e920 (Add listeners for Edge events):code/media/src/test/java/com/adobe/marketing/mobile/media/internal/MediaExtensionTests.java
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -36,6 +40,7 @@ public class MediaExtensionTests {
     MediaExtension mediaExtension;
     ExtensionApi mockExtensionAPI;
     MediaState mockMediaState;
+    private MediaEventProcessor mockMediaEventProcessor;
 
     Map<String, ExtensionEventListener> eventListerMap;
 
@@ -56,6 +61,7 @@ public class MediaExtensionTests {
         mediaExtension = new MediaExtension(mockExtensionAPI);
 
         mockMediaState = mock(MediaState.class);
+        mockMediaEventProcessor = mock(MediaEventProcessor.class);
 
         eventListerMap = new HashMap<>();
         Mockito.doAnswer(
@@ -76,6 +82,7 @@ public class MediaExtensionTests {
         mediaExtension.onRegistered();
 
         mediaExtension.mediaState = mockMediaState;
+        mediaExtension.mediaEventProcessor = mockMediaEventProcessor;
     }
 
     @Test
@@ -140,5 +147,421 @@ public class MediaExtensionTests {
         resetListener.hear(event);
 
         assertTrue(mediaExtension.trackers.isEmpty());
+    }
+
+    @Test
+    public void
+            testHandleEdgeMediaSessionDetails_validRequestId_validSessionId_callsEventProcessor() {
+        final String expectedRequestEventId = "event123";
+        final String expectedBackendSessionId =
+                "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("sessionId", expectedBackendSessionId);
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(1))
+                .notifyBackendSessionId(expectedRequestEventId, expectedBackendSessionId);
+    }
+
+    @Test
+    public void testHandleEdgeMediaSessionDetails_validRequestId_noSessionId_callsEventProcessor() {
+        final String expectedRequestEventId = "event123";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("invalid", "no session id");
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(1))
+                .notifyBackendSessionId(expectedRequestEventId, null);
+    }
+
+    @Test
+    public void
+            testHandleEdgeMediaSessionDetails_validRequestId_emptySessionId_callsEventProcessor() {
+        final String expectedRequestEventId = "event123";
+        final String expectedBackendSessionId = "";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("sessionId", expectedBackendSessionId);
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(1))
+                .notifyBackendSessionId(expectedRequestEventId, expectedBackendSessionId);
+    }
+
+    @Test
+    public void testHandleEdgeMediaSessionDetails_validRequestId_noPayload_callsEventProcessor() {
+        final String expectedRequestEventId = "event123";
+
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(1))
+                .notifyBackendSessionId(expectedRequestEventId, null);
+    }
+
+    @Test
+    public void testHandleEdgeMediaSessionDetails_noRequestId_doesNotCallEventProcessor() {
+        final String expectedBackendSessionId =
+                "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("sessionId", expectedBackendSessionId);
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyBackendSessionId(any(), any());
+    }
+
+    @Test
+    public void testHandleEdgeMediaSessionDetails_nullRequestId_doesNotCallEventProcessor() {
+        final String expectedRequestEventId = null;
+        final String expectedBackendSessionId =
+                "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("sessionId", expectedBackendSessionId);
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyBackendSessionId(any(), any());
+    }
+
+    @Test
+    public void testHandleEdgeMediaSessionDetails_emptyRequestId_doesNotCallEventProcessor() {
+        final String expectedRequestEventId = "";
+        final String expectedBackendSessionId =
+                "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "payload",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("sessionId", expectedBackendSessionId);
+                                    }
+                                });
+                    }
+                });
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyBackendSessionId(any(), any());
+    }
+
+    @Test
+    public void testHandleEdgeErrorResponse_validRequestId_validEventData_callsEventProcessor() {
+        final String expectedRequestEventId = "event123";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "errors",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put(
+                                                "type",
+                                                "https://ns.adobe.com/aep/errors/va-edge-0404-404");
+                                        put("status", 404);
+                                        put("title", "Not Found");
+                                    }
+                                });
+                    }
+                });
+
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(1))
+                .notifyErrorResponse(expectedRequestEventId, event.getEventData());
+    }
+
+    @Test
+    public void testHandleEdgeErrorResponse_noRequestId_validEventData_doesNotCallEventProcessor() {
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put(
+                "errors",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put(
+                                                "type",
+                                                "https://ns.adobe.com/aep/errors/va-edge-0404-404");
+                                        put("status", 404);
+                                        put("title", "Not Found");
+                                    }
+                                });
+                    }
+                });
+
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
+    }
+
+    @Test
+    public void
+            testHandleEdgeErrorResponse_nullRequestId_validEventData_doesNotCallEventProcessor() {
+        final String expectedRequestEventId = null;
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "errors",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put(
+                                                "type",
+                                                "https://ns.adobe.com/aep/errors/va-edge-0404-404");
+                                        put("status", 404);
+                                        put("title", "Not Found");
+                                    }
+                                });
+                    }
+                });
+
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
+    }
+
+    @Test
+    public void
+            testHandleEdgeErrorResponse_emptyRequestId_validEventData_doesNotCallEventProcessor() {
+        final String expectedRequestEventId = "";
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("requestEventId", expectedRequestEventId);
+        eventData.put(
+                "errors",
+                new ArrayList<Map<String, Object>>() {
+                    {
+                        add(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put(
+                                                "type",
+                                                "https://ns.adobe.com/aep/errors/va-edge-0404-404");
+                                        put("status", 404);
+                                        put("title", "Not Found");
+                                    }
+                                });
+                    }
+                });
+
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                        .setEventData(eventData)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
+    }
+
+    @Test
+    public void testHandleEdgeErrorResponse_noEventData_doesNotCallEventProcessor() {
+        Event event =
+                new Event.Builder(
+                                "Edge Media Session",
+                                EventType.EDGE,
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                        .build();
+
+        ExtensionEventListener listener =
+                getListener(
+                        EventType.EDGE,
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+        listener.hear(event);
+
+        verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
     }
 }

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -409,14 +409,14 @@ public class MediaExtensionTests {
                 new Event.Builder(
                                 "Edge Error Response",
                                 EventType.EDGE,
-                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE)
                         .setEventData(eventData)
                         .build();
 
         ExtensionEventListener listener =
                 getListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(1))
@@ -447,14 +447,14 @@ public class MediaExtensionTests {
                 new Event.Builder(
                                 "Edge Error Response",
                                 EventType.EDGE,
-                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE)
                         .setEventData(eventData)
                         .build();
 
         ExtensionEventListener listener =
                 getListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
@@ -487,14 +487,14 @@ public class MediaExtensionTests {
                 new Event.Builder(
                                 "Edge Error Response",
                                 EventType.EDGE,
-                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE)
                         .setEventData(eventData)
                         .build();
 
         ExtensionEventListener listener =
                 getListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
@@ -527,14 +527,14 @@ public class MediaExtensionTests {
                 new Event.Builder(
                                 "Edge Error Response",
                                 EventType.EDGE,
-                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE)
                         .setEventData(eventData)
                         .build();
 
         ExtensionEventListener listener =
                 getListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());
@@ -546,13 +546,13 @@ public class MediaExtensionTests {
                 new Event.Builder(
                                 "Edge Error Response",
                                 EventType.EDGE,
-                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE)
+                                MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE)
                         .build();
 
         ExtensionEventListener listener =
                 getListener(
                         EventType.EDGE,
-                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESOURCE);
+                        MediaInternalConstants.Media.EVENT_SOURCE_EDGE_ERROR_RESPONSE);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).notifyErrorResponse(any(), any());

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -50,7 +50,6 @@ public class MediaExtensionTests {
 
     MediaExtension mediaExtension;
     ExtensionApi mockExtensionAPI;
-    MediaState mockMediaState;
     private MediaEventProcessor mockMediaEventProcessor;
 
     Map<String, ExtensionEventListener> eventListerMap;
@@ -63,7 +62,6 @@ public class MediaExtensionTests {
         mockExtensionAPI = mock(ExtensionApi.class);
         mediaExtension = new MediaExtension(mockExtensionAPI);
 
-        mockMediaState = mock(MediaState.class);
         mockMediaEventProcessor = mock(MediaEventProcessor.class);
 
         eventListerMap = new HashMap<>();
@@ -84,7 +82,6 @@ public class MediaExtensionTests {
 
         mediaExtension.onRegistered();
 
-        mediaExtension.mediaState = mockMediaState;
         mediaExtension.mediaEventProcessor = mockMediaEventProcessor;
     }
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -29,16 +29,14 @@ import com.adobe.marketing.mobile.ExtensionEventListener;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
-
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 public class MediaExtensionTests {
 
@@ -561,13 +559,12 @@ public class MediaExtensionTests {
     }
 
     @Test
-    public void
-    testHandleConfigurationResponseEvent_setSharedState_callsEventProcessor() {
+    public void testHandleConfigurationResponseEvent_setSharedState_callsEventProcessor() {
         Event event =
                 new Event.Builder(
-                        "Configuration",
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT)
+                                "Configuration",
+                                EventType.CONFIGURATION,
+                                EventSource.RESPONSE_CONTENT)
                         .build();
         Map<String, Object> configState = new HashMap<>();
         configState.put("media.channel", "testing");
@@ -580,25 +577,26 @@ public class MediaExtensionTests {
                             }
                         })
                 .when(mockExtensionAPI)
-                .getSharedState(eq("com.adobe.module.configuration"), eq(event), anyBoolean(), any(SharedStateResolution.class));
+                .getSharedState(
+                        eq("com.adobe.module.configuration"),
+                        eq(event),
+                        anyBoolean(),
+                        any(SharedStateResolution.class));
 
         ExtensionEventListener listener =
-                getListener(
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT);
+                getListener(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(1)).updateMediaState(eq(configState));
     }
 
     @Test
-    public void
-    testHandleConfigurationResponseEvent_nullSharedState_doesNotCallEventProcessor() {
+    public void testHandleConfigurationResponseEvent_nullSharedState_doesNotCallEventProcessor() {
         Event event =
                 new Event.Builder(
-                        "Configuration",
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT)
+                                "Configuration",
+                                EventType.CONFIGURATION,
+                                EventSource.RESPONSE_CONTENT)
                         .build();
 
         Mockito.doAnswer(
@@ -609,54 +607,58 @@ public class MediaExtensionTests {
                             }
                         })
                 .when(mockExtensionAPI)
-                .getSharedState(eq("com.adobe.module.configuration"), eq(event), anyBoolean(), any(SharedStateResolution.class));
+                .getSharedState(
+                        eq("com.adobe.module.configuration"),
+                        eq(event),
+                        anyBoolean(),
+                        any(SharedStateResolution.class));
 
         ExtensionEventListener listener =
-                getListener(
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT);
+                getListener(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).updateMediaState(any());
     }
 
     @Test
-    public void
-    testHandleConfigurationResponseEvent_emptySharedState_doesNotCallEventProcessor() {
+    public void testHandleConfigurationResponseEvent_emptySharedState_doesNotCallEventProcessor() {
         Event event =
                 new Event.Builder(
-                        "Configuration",
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT)
+                                "Configuration",
+                                EventType.CONFIGURATION,
+                                EventSource.RESPONSE_CONTENT)
                         .build();
 
         Mockito.doAnswer(
                         new Answer<SharedStateResult>() {
                             @Override
                             public SharedStateResult answer(final InvocationOnMock invocation) {
-                                return new SharedStateResult(SharedStateStatus.PENDING, Collections.<String, Object>emptyMap());
+                                return new SharedStateResult(
+                                        SharedStateStatus.PENDING,
+                                        Collections.<String, Object>emptyMap());
                             }
                         })
                 .when(mockExtensionAPI)
-                .getSharedState(eq("com.adobe.module.configuration"), eq(event), anyBoolean(), any(SharedStateResolution.class));
+                .getSharedState(
+                        eq("com.adobe.module.configuration"),
+                        eq(event),
+                        anyBoolean(),
+                        any(SharedStateResolution.class));
 
         ExtensionEventListener listener =
-                getListener(
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT);
+                getListener(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).updateMediaState(any());
     }
 
     @Test
-    public void
-    testHandleConfigurationResponseEvent_nullResult_doesNotCallEventProcessor() {
+    public void testHandleConfigurationResponseEvent_nullResult_doesNotCallEventProcessor() {
         Event event =
                 new Event.Builder(
-                        "Configuration",
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT)
+                                "Configuration",
+                                EventType.CONFIGURATION,
+                                EventSource.RESPONSE_CONTENT)
                         .build();
 
         Mockito.doAnswer(
@@ -667,12 +669,14 @@ public class MediaExtensionTests {
                             }
                         })
                 .when(mockExtensionAPI)
-                .getSharedState(eq("com.adobe.module.configuration"), eq(event), anyBoolean(), any(SharedStateResolution.class));
+                .getSharedState(
+                        eq("com.adobe.module.configuration"),
+                        eq(event),
+                        anyBoolean(),
+                        any(SharedStateResolution.class));
 
         ExtensionEventListener listener =
-                getListener(
-                        EventType.CONFIGURATION,
-                        EventSource.RESPONSE_CONTENT);
+                getListener(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT);
         listener.hear(event);
 
         verify(mockMediaEventProcessor, times(0)).updateMediaState(any());

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtensionTests.java
@@ -138,7 +138,7 @@ public class MediaExtensionTests {
     }
 
     @Test
-    public void testRequestReset() {
+    public void testRequestReset_deletesTrackers_abortsSessions() {
         MediaTrackerInterface tracker = mock(MediaTrackerInterface.class);
         mediaExtension.trackers.put("key", tracker);
         Event event =
@@ -150,6 +150,7 @@ public class MediaExtensionTests {
         resetListener.hear(event);
 
         assertTrue(mediaExtension.trackers.isEmpty());
+        verify(mockMediaEventProcessor, times(1)).abortAllSessions();
     }
 
     @Test

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaStateTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaStateTests.java
@@ -74,7 +74,7 @@ public class MediaStateTests {
     }
 
     @Test
-    public void test_getMediaChannel() {
+    public void test_updateState_getMediaChannel() {
         testStringState(
                 MediaTestConstants.Configuration.MEDIA_CHANNEL,
                 new TestCallback() {
@@ -87,7 +87,7 @@ public class MediaStateTests {
     }
 
     @Test
-    public void test_getMediaPlayerName() {
+    public void test_updateState_getMediaPlayerName() {
         testStringState(
                 MediaTestConstants.Configuration.MEDIA_PLAYER_NAME,
                 new TestCallback() {
@@ -100,7 +100,7 @@ public class MediaStateTests {
     }
 
     @Test
-    public void test_getMediaAPPVersion() {
+    public void test_updateState_getMediaAPPVersion() {
         testStringState(
                 MediaTestConstants.Configuration.MEDIA_APP_VERSION,
                 new TestCallback() {
@@ -110,5 +110,69 @@ public class MediaStateTests {
                     }
                 },
                 null);
+    }
+
+    @Test
+    public void test_isValid_validPlayerName_validChannel_validAppVersion_isValidTrue() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.playerName", "name");
+        states.put("media.channel", "channel");
+        states.put("media.appVersion", "1.0.0");
+        mediaState.updateState(states);
+
+        assertTrue(mediaState.isValid());
+    }
+
+    @Test
+    public void test_isValid_validPlayerName_validChannel_noAppVersion_isValidTrue() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.playerName", "name");
+        states.put("media.channel", "channel");
+        mediaState.updateState(states);
+
+        // Is valid if playerName and channel are valid, appVersion not considered
+        assertTrue(mediaState.isValid());
+    }
+
+    @Test
+    public void test_isValid_validPlayerName_noChannel_validAppVersion_isValidFalse() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.playerName", "name");
+        states.put("media.appVersion", "1.0.0");
+        mediaState.updateState(states);
+
+        assertFalse(mediaState.isValid());
+    }
+
+    @Test
+    public void test_isValid_noPlayerName_validChannel_validAppVersion_isValidFalse() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.channel", "channel");
+        states.put("media.appVersion", "1.0.0");
+        mediaState.updateState(states);
+
+        assertFalse(mediaState.isValid());
+    }
+
+    @Test
+    public void test_isValid_validPlayerName_emptyChannel_validAppVersion_isValidFalse() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.playerName", "name");
+        states.put("media.channel", "");
+        states.put("media.appVersion", "1.0.0");
+        mediaState.updateState(states);
+
+        assertFalse(mediaState.isValid());
+    }
+
+    @Test
+    public void test_isValid_emptyPlayerName_validChannel_validAppVersion_isValidFalse() {
+        Map<String, Object> states = new HashMap<>();
+        states.put("media.playerName", "");
+        states.put("media.channel", "channel");
+        states.put("media.appVersion", "1.0.0");
+        mediaState.updateState(states);
+
+        assertFalse(mediaState.isValid());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Register Media extension listeners for:

- Edge media-analytics:new-session
- Edge error response content
- Configuration response content

Adds stub for MediaEventProcessor.

Cleans up MediaState by removing all properties except for "media.playerName", "media.channel", and "media.appVersion".

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
