### PR TITLE
Add XDM data model classes

### DIFF
--- a/code/edgemedia/build.gradle
+++ b/code/edgemedia/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:4.5.1"
     testImplementation 'org.mockito:mockito-inline:4.5.1'
+    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.0'
     //noinspection GradleDependency
     testImplementation 'org.json:json:20180813'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
@@ -11,18 +11,19 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMAdvertisingDetails : XDMProperty {
-    var friendlyName: String? = null
-    var length: Long? = null
-    var name: String? = null
-    var podPosition: Long? = null
-    var playerName: String? = null
-    var advertiser: String? = null
-    var campaignID: String? = null
-    var creativeID: String? = null
-    var creativeURL: String? = null
-    var placementID: String? = null
+data class XDMAdvertisingDetails(
+    var friendlyName: String? = null,
+    var length: Long? = null,
+    var name: String? = null,
+    var podPosition: Long? = null,
+    var playerName: String? = null,
+    var advertiser: String? = null,
+    var campaignID: String? = null,
+    var creativeID: String? = null,
+    var creativeURL: String? = null,
+    var placementID: String? = null,
     var siteID: String? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
@@ -1,0 +1,76 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMAdvertisingDetails : XDMProperty {
+    var friendlyName: String? = null
+    var length: Long? = null
+    var name: String? = null
+    var podPosition: Long? = null
+    var playerName: String? = null
+    var advertiser: String? = null
+    var campaignID: String? = null
+    var creativeID: String? = null
+    var creativeURL: String? = null
+    var placementID: String? = null
+    var siteID: String? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        friendlyName?.let {
+            map.put("friendlyName", it)
+        }
+
+        length?.let {
+            map.put("length", it)
+        }
+
+        name?.let {
+            map.put("name", it)
+        }
+
+        podPosition?.let {
+            map.put("podPosition", it)
+        }
+
+        playerName?.let {
+            map.put("playerName", it)
+        }
+
+        advertiser?.let {
+            map.put("advertiser", it)
+        }
+
+        campaignID?.let {
+            map.put("campaignID", it)
+        }
+
+        creativeID?.let {
+            map.put("creativeID", it)
+        }
+
+        creativeURL?.let {
+            map.put("creativeURL", it)
+        }
+
+        placementID?.let {
+            map.put("placementID", it)
+        }
+
+        siteID?.let {
+            map.put("siteID", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMAdvertisingDetails(
+internal data class XDMAdvertisingDetails(
     var friendlyName: String? = null,
     var length: Long? = null,
     var name: String? = null,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
@@ -11,10 +11,11 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMAdvertisingPodDetails : XDMProperty {
-    var friendlyName: String? = null
-    var index: Long? = null
+data class XDMAdvertisingPodDetails(
+    var friendlyName: String? = null,
+    var index: Long? = null,
     var offset: Long? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
@@ -1,0 +1,36 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMAdvertisingPodDetails : XDMProperty {
+    var friendlyName: String? = null
+    var index: Long? = null
+    var offset: Long? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        friendlyName?.let {
+            map.put("friendlyName", it)
+        }
+
+        index?.let {
+            map.put("index", it)
+        }
+
+        offset?.let {
+            map.put("offset", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMAdvertisingPodDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMAdvertisingPodDetails(
+internal data class XDMAdvertisingPodDetails(
     var friendlyName: String? = null,
     var index: Long? = null,
     var offset: Long? = null

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMChapterDetails(
+internal data class XDMChapterDetails(
     var friendlyName: String? = null,
     var index: Long? = null,
     var length: Long? = null,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
@@ -1,0 +1,41 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMChapterDetails : XDMProperty {
+    var friendlyName: String? = null
+    var index: Long? = null
+    var length: Long? = null
+    var offset: Long? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        friendlyName?.let {
+            map.put("friendlyName", it)
+        }
+
+        index?.let {
+            map.put("index", it)
+        }
+
+        length?.let {
+            map.put("length", it)
+        }
+
+        offset?.let {
+            map.put("offset", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMChapterDetails.kt
@@ -11,11 +11,12 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMChapterDetails : XDMProperty {
-    var friendlyName: String? = null
-    var index: Long? = null
-    var length: Long? = null
+data class XDMChapterDetails(
+    var friendlyName: String? = null,
+    var index: Long? = null,
+    var length: Long? = null,
     var offset: Long? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
@@ -11,9 +11,10 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMCustomMetadata : XDMProperty {
-    var name: String? = null
+data class XDMCustomMetadata(
+    var name: String? = null,
     var value: String? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMCustomMetadata(
+internal data class XDMCustomMetadata(
     var name: String? = null,
     var value: String? = null
 ) : XDMProperty {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMCustomMetadata.kt
@@ -1,0 +1,31 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMCustomMetadata : XDMProperty {
+    var name: String? = null
+    var value: String? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        name?.let {
+            map.put("name", it)
+        }
+
+        value?.let {
+            map.put("value", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMErrorDetails(
+internal data class XDMErrorDetails(
     var name: String? = null,
     var source: String? = null
 ) : XDMProperty {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
@@ -1,0 +1,31 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMErrorDetails : XDMProperty {
+    var name: String? = null
+    var source: String? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        name?.let {
+            map.put("name", it)
+        }
+
+        source?.let {
+            map.put("source", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMErrorDetails.kt
@@ -11,9 +11,10 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMErrorDetails : XDMProperty {
-    var name: String? = null
+data class XDMErrorDetails(
+    var name: String? = null,
     var source: String? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMMediaCollection(
+internal data class XDMMediaCollection(
     var advertisingDetails: XDMAdvertisingDetails? = null,
     var advertisingPodDetails: XDMAdvertisingPodDetails? = null,
     var chapterDetails: XDMChapterDetails? = null,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
@@ -1,0 +1,76 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMMediaCollection : XDMProperty {
+    var advertisingDetails: XDMAdvertisingDetails? = null
+    var advertisingPodDetails: XDMAdvertisingPodDetails? = null
+    var chapterDetails: XDMChapterDetails? = null
+    var customMetadata: List<XDMCustomMetadata>? = null
+    var errorDetails: XDMErrorDetails? = null
+    var playHead: Long? = null
+    var qoeDataDetails: XDMQoeDataDetails? = null
+    var sessionDetails: XDMSessionDetails? = null
+    var sessionID: String? = null
+    var statesStart: List<XDMPlayerStateData>? = null
+    var statesEnd: List<XDMPlayerStateData>? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        advertisingDetails?.let {
+            map.put("advertisingDetails", it.serializeToXDM())
+        }
+
+        advertisingPodDetails?.let {
+            map.put("advertisingPodDetails", it.serializeToXDM())
+        }
+
+        chapterDetails?.let {
+            map.put("chapterDetails", it.serializeToXDM())
+        }
+
+        customMetadata?.let {
+            map.put("customMetadata", serializeFromList(it))
+        }
+
+        errorDetails?.let {
+            map.put("errorDetails", it.serializeToXDM())
+        }
+
+        playHead?.let {
+            map.put("playHead", it)
+        }
+
+        qoeDataDetails?.let {
+            map.put("qoeDataDetails", it.serializeToXDM())
+        }
+
+        sessionDetails?.let {
+            map.put("sessionDetails", it.serializeToXDM())
+        }
+
+        sessionID?.let {
+            map.put("sessionID", it)
+        }
+
+        statesStart?.let {
+            map.put("statesStart", serializeFromList(it))
+        }
+
+        statesEnd?.let {
+            map.put("statesEnd", serializeFromList(it))
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
@@ -17,7 +17,7 @@ internal data class XDMMediaCollection(
     var chapterDetails: XDMChapterDetails? = null,
     var customMetadata: List<XDMCustomMetadata>? = null,
     var errorDetails: XDMErrorDetails? = null,
-    var playHead: Long? = null,
+    var playhead: Long? = null,
     var qoeDataDetails: XDMQoeDataDetails? = null,
     var sessionDetails: XDMSessionDetails? = null,
     var sessionID: String? = null,
@@ -48,8 +48,8 @@ internal data class XDMMediaCollection(
             map.put("errorDetails", it.serializeToXDM())
         }
 
-        playHead?.let {
-            map.put("playHead", it)
+        playhead?.let {
+            map.put("playhead", it)
         }
 
         qoeDataDetails?.let {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaCollection.kt
@@ -11,18 +11,19 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMMediaCollection : XDMProperty {
-    var advertisingDetails: XDMAdvertisingDetails? = null
-    var advertisingPodDetails: XDMAdvertisingPodDetails? = null
-    var chapterDetails: XDMChapterDetails? = null
-    var customMetadata: List<XDMCustomMetadata>? = null
-    var errorDetails: XDMErrorDetails? = null
-    var playHead: Long? = null
-    var qoeDataDetails: XDMQoeDataDetails? = null
-    var sessionDetails: XDMSessionDetails? = null
-    var sessionID: String? = null
-    var statesStart: List<XDMPlayerStateData>? = null
+data class XDMMediaCollection(
+    var advertisingDetails: XDMAdvertisingDetails? = null,
+    var advertisingPodDetails: XDMAdvertisingPodDetails? = null,
+    var chapterDetails: XDMChapterDetails? = null,
+    var customMetadata: List<XDMCustomMetadata>? = null,
+    var errorDetails: XDMErrorDetails? = null,
+    var playHead: Long? = null,
+    var qoeDataDetails: XDMQoeDataDetails? = null,
+    var sessionDetails: XDMSessionDetails? = null,
+    var sessionID: String? = null,
+    var statesStart: List<XDMPlayerStateData>? = null,
     var statesEnd: List<XDMPlayerStateData>? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
@@ -1,0 +1,33 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+enum class XDMMediaEventType(val value: String) {
+    SESSION_START("media.sessionStart"),
+    SESSION_COMPLETE("media.sessionComplete"),
+    SESSION_END("media.sessionEnd"),
+    PLAY("media.play"),
+    PAUSE_START("media.pauseStart"),
+    PING("media.ping"),
+    ERROR("media.error"),
+    BUFFER_START("media.bufferStart"),
+    BITRATE_CHANGE("media.bitrateChange"),
+    AD_BREAK_START("media.adBreakStart"),
+    AD_BREAK_COMPLETE("media.adBreakComplete"),
+    AD_START("media.adStart"),
+    AD_SKIP("media.adSkip"),
+    AD_COMPLETE("media.adComplete"),
+    CHAPTER_SKIP("media.chapterSkip"),
+    CHAPTER_START("media.chapterStart"),
+    CHAPTER_COMPLETE("media.chapterComplete"),
+    STATES_UPDATE("media.statesUpdate")
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-enum class XDMMediaEventType(val value: String) {
+internal enum class XDMMediaEventType(val value: String) {
     SESSION_START("media.sessionStart"),
     SESSION_COMPLETE("media.sessionComplete"),
     SESSION_END("media.sessionEnd"),

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
@@ -11,8 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMPlayerStateData : XDMProperty {
-    var name: String? = null
+data class XDMPlayerStateData(var name: String? = null) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMPlayerStateData(var name: String? = null) : XDMProperty {
+internal data class XDMPlayerStateData(var name: String? = null) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPlayerStateData.kt
@@ -1,0 +1,26 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMPlayerStateData : XDMProperty {
+    var name: String? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        name?.let {
+            map.put("name", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMProperty.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMProperty.kt
@@ -1,0 +1,37 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+interface XDMProperty {
+
+    /**
+     * Serializes this [XDMProperty] object to a map equivalent of its XDM schema.
+     * @return XDM formatted map of this [XDMProperty] object
+     */
+    fun serializeToXDM(): Map<String, Any>
+
+    /**
+     * Serialize a list of [XDMProperty] elements to a list of XDM formatted [Map]s.
+     * Calls [XDMProperty.serializeToXDM] on each element in the list.
+     *
+     * @param properties list of [XDMProperty] elements
+     * @return list of [XDMProperty] elements serialized to XDM formatted [Map]
+     */
+    fun serializeFromList(properties: List<XDMProperty>): List<Map<String, Any>> {
+        val list = mutableListOf<Map<String, Any>>()
+        for (property in properties) {
+            list.add(property.serializeToXDM())
+        }
+
+        return list.toList()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMProperty.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMProperty.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-interface XDMProperty {
+internal interface XDMProperty {
 
     /**
      * Serializes this [XDMProperty] object to a map equivalent of its XDM schema.

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
@@ -11,11 +11,12 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMQoeDataDetails : XDMProperty {
-    var bitrate: Long? = null
-    var droppedFrames: Long? = null
-    var framesPerSecond: Long? = null
+data class XDMQoeDataDetails(
+    var bitrate: Long? = null,
+    var droppedFrames: Long? = null,
+    var framesPerSecond: Long? = null,
     var timeToStart: Long? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMQoeDataDetails(
+internal data class XDMQoeDataDetails(
     var bitrate: Long? = null,
     var droppedFrames: Long? = null,
     var framesPerSecond: Long? = null,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
@@ -1,0 +1,41 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMQoeDataDetails : XDMProperty {
+    var bitrate: Long? = null
+    var droppedFrames: Long? = null
+    var framesPerSecond: Long? = null
+    var timeToStart: Long? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        bitrate?.let {
+            map.put("bitrate", it)
+        }
+
+        droppedFrames?.let {
+            map.put("droppedFrames", it)
+        }
+
+        framesPerSecond?.let {
+            map.put("framesPerSecond", it)
+        }
+
+        timeToStart?.let {
+            map.put("timeToStart", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
@@ -1,0 +1,196 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+class XDMSessionDetails : XDMProperty {
+    // Required fields sourced from APIs
+    var contentType: String? = null
+    var name: String? = null
+    var friendlyName: String? = null
+    var hasResume: Boolean? = null
+    var length: Long? = null
+    var streamType: XDMStreamType? = null
+
+    // Required fields sourced from media configuration
+    var channel: String? = null
+    var playerName: String? = null
+
+    // Optional field sourced from media configuration
+    var appVersion: String? = null
+
+    // Optional metadata fields
+    // Audio Standard Metadata
+    var album: String? = null
+    var artist: String? = null
+    var author: String? = null
+    var label: String? = null
+    var publisher: String? = null
+    var station: String? = null
+
+    // Video Standard Metadata
+    var adLoad: String? = null
+    var authorized: String? = null
+    var assetID: String? = null
+    var dayPart: String? = null
+    var episode: String? = null
+    var feed: String? = null
+    var firstAirDate: String? = null
+    var firstDigitalDate: String? = null
+    var genre: String? = null
+    var mvpd: String? = null
+    var network: String? = null
+    var originator: String? = null
+    var rating: String? = null
+    var season: String? = null
+    var segment: String? = null
+    var show: String? = null
+    var showType: String? = null
+    var streamFormat: String? = null
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        contentType?.let {
+            map.put("contentType", it)
+        }
+
+        name?.let {
+            map.put("name", it)
+        }
+
+        friendlyName?.let {
+            map.put("friendlyName", it)
+        }
+
+        hasResume?.let {
+            map.put("hasResume", it)
+        }
+
+        length?.let {
+            map.put("length", it)
+        }
+
+        streamType?.let {
+            map.put("streamType", it.value)
+        }
+
+        channel?.let {
+            map.put("channel", it)
+        }
+
+        playerName?.let {
+            map.put("playerName", it)
+        }
+
+        appVersion?.let {
+            map.put("appVersion", it)
+        }
+
+        album?.let {
+            map.put("album", it)
+        }
+
+        artist?.let {
+            map.put("artist", it)
+        }
+
+        author?.let {
+            map.put("author", it)
+        }
+
+        label?.let {
+            map.put("label", it)
+        }
+
+        publisher?.let {
+            map.put("publisher", it)
+        }
+
+        station?.let {
+            map.put("station", it)
+        }
+
+        adLoad?.let {
+            map.put("adLoad", it)
+        }
+
+        authorized?.let {
+            map.put("authorized", it)
+        }
+
+        assetID?.let {
+            map.put("assetID", it)
+        }
+
+        dayPart?.let {
+            map.put("dayPart", it)
+        }
+
+        episode?.let {
+            map.put("episode", it)
+        }
+
+        feed?.let {
+            map.put("feed", it)
+        }
+
+        firstAirDate?.let {
+            map.put("firstAirDate", it)
+        }
+
+        firstDigitalDate?.let {
+            map.put("firstDigitalDate", it)
+        }
+
+        genre?.let {
+            map.put("genre", it)
+        }
+
+        mvpd?.let {
+            map.put("mvpd", it)
+        }
+
+        network?.let {
+            map.put("network", it)
+        }
+
+        originator?.let {
+            map.put("originator", it)
+        }
+
+        rating?.let {
+            map.put("rating", it)
+        }
+
+        season?.let {
+            map.put("season", it)
+        }
+
+        segment?.let {
+            map.put("segment", it)
+        }
+
+        show?.let {
+            map.put("show", it)
+        }
+
+        showType?.let {
+            map.put("showType", it)
+        }
+
+        streamFormat?.let {
+            map.put("streamFormat", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
@@ -11,50 +11,51 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-class XDMSessionDetails : XDMProperty {
+data class XDMSessionDetails(
     // Required fields sourced from APIs
-    var contentType: String? = null
-    var name: String? = null
-    var friendlyName: String? = null
-    var hasResume: Boolean? = null
-    var length: Long? = null
-    var streamType: XDMStreamType? = null
+    var contentType: String? = null,
+    var name: String? = null,
+    var friendlyName: String? = null,
+    var hasResume: Boolean? = null,
+    var length: Long? = null,
+    var streamType: XDMStreamType? = null,
 
     // Required fields sourced from media configuration
-    var channel: String? = null
-    var playerName: String? = null
+    var channel: String? = null,
+    var playerName: String? = null,
 
     // Optional field sourced from media configuration
-    var appVersion: String? = null
+    var appVersion: String? = null,
 
     // Optional metadata fields
     // Audio Standard Metadata
-    var album: String? = null
-    var artist: String? = null
-    var author: String? = null
-    var label: String? = null
-    var publisher: String? = null
-    var station: String? = null
+    var album: String? = null,
+    var artist: String? = null,
+    var author: String? = null,
+    var label: String? = null,
+    var publisher: String? = null,
+    var station: String? = null,
 
     // Video Standard Metadata
-    var adLoad: String? = null
-    var authorized: String? = null
-    var assetID: String? = null
-    var dayPart: String? = null
-    var episode: String? = null
-    var feed: String? = null
-    var firstAirDate: String? = null
-    var firstDigitalDate: String? = null
-    var genre: String? = null
-    var mvpd: String? = null
-    var network: String? = null
-    var originator: String? = null
-    var rating: String? = null
-    var season: String? = null
-    var segment: String? = null
-    var show: String? = null
-    var showType: String? = null
+    var adLoad: String? = null,
+    var authorized: String? = null,
+    var assetID: String? = null,
+    var dayPart: String? = null,
+    var episode: String? = null,
+    var feed: String? = null,
+    var firstAirDate: String? = null,
+    var firstDigitalDate: String? = null,
+    var genre: String? = null,
+    var mvpd: String? = null,
+    var network: String? = null,
+    var originator: String? = null,
+    var rating: String? = null,
+    var season: String? = null,
+    var segment: String? = null,
+    var show: String? = null,
+    var showType: String? = null,
     var streamFormat: String? = null
+) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
@@ -14,10 +14,10 @@ package com.adobe.marketing.mobile.edge.media.internal.xdm
 internal data class XDMSessionDetails(
     // Required fields sourced from APIs
     var contentType: String? = null,
-    var name: String? = null,
     var friendlyName: String? = null,
     var hasResume: Boolean? = null,
     var length: Long? = null,
+    var name: String? = null,
     var streamType: XDMStreamType? = null,
 
     // Required fields sourced from media configuration
@@ -64,10 +64,6 @@ internal data class XDMSessionDetails(
             map.put("contentType", it)
         }
 
-        name?.let {
-            map.put("name", it)
-        }
-
         friendlyName?.let {
             map.put("friendlyName", it)
         }
@@ -78,6 +74,10 @@ internal data class XDMSessionDetails(
 
         length?.let {
             map.put("length", it)
+        }
+
+        name?.let {
+            map.put("name", it)
         }
 
         streamType?.let {

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMSessionDetails.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-data class XDMSessionDetails(
+internal data class XDMSessionDetails(
     // Required fields sourced from APIs
     var contentType: String? = null,
     var name: String? = null,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMStreamType.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMStreamType.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
-enum class XDMStreamType(val value: String) {
+internal enum class XDMStreamType(val value: String) {
     AUDIO("audio"),
     VIDEO("video")
 }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMStreamType.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMStreamType.kt
@@ -1,0 +1,17 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+enum class XDMStreamType(val value: String) {
+    AUDIO("audio"),
+    VIDEO("video")
+}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -1,0 +1,778 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.full.memberProperties
+
+class XDMPropertyTests {
+
+    @Test
+    fun `XDMAdvertisingDetails serializeToXDM all properties`() {
+        val advertisingDetails = XDMAdvertisingDetails()
+        advertisingDetails.name = "id"
+        advertisingDetails.friendlyName = "name"
+        advertisingDetails.length = 10
+        advertisingDetails.podPosition = 1
+        advertisingDetails.playerName = "testPlayer"
+        advertisingDetails.advertiser = "testAdvertiser"
+        advertisingDetails.campaignID = "testCampaignId"
+        advertisingDetails.creativeID = "testCreativeId"
+        advertisingDetails.creativeURL = "testCreativeUrl"
+        advertisingDetails.placementID = "testPlacementId"
+        advertisingDetails.siteID = "testSiteId"
+
+        val xdm = advertisingDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "name" to "id",
+            "friendlyName" to "name",
+            "length" to 10L,
+            "podPosition" to 1L,
+            "playerName" to "testPlayer",
+            "advertiser" to "testAdvertiser",
+            "campaignID" to "testCampaignId",
+            "creativeID" to "testCreativeId",
+            "creativeURL" to "testCreativeUrl",
+            "placementID" to "testPlacementId",
+            "siteID" to "testSiteId"
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMAdvertisingDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMAdvertisingDetails serializeToXDM no properties returns empty map`() {
+        val advertisingDetails = XDMAdvertisingDetails()
+        val xdm = advertisingDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMAdvertisingPodDetails serializeToXDM all properties`() {
+        val advertisingPodDetails = XDMAdvertisingPodDetails()
+        advertisingPodDetails.friendlyName = "name"
+        advertisingPodDetails.index = 1
+        advertisingPodDetails.offset = 2
+
+        val xdm = advertisingPodDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "friendlyName" to "name",
+            "index" to 1L,
+            "offset" to 2L
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMAdvertisingPodDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMAdvertisingPodDetails serializeToXDM no properties returns empty map`() {
+        val advertisingPodDetails = XDMAdvertisingPodDetails()
+        val xdm = advertisingPodDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMChapterDetails serializeToXDM all properties`() {
+        val chapterDetails = XDMChapterDetails()
+        chapterDetails.friendlyName = "test friendly name"
+        chapterDetails.index = 1
+        chapterDetails.length = 10
+        chapterDetails.offset = 2
+
+        val xdm = chapterDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "friendlyName" to "test friendly name",
+            "index" to 1L,
+            "length" to 10L,
+            "offset" to 2L
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMChapterDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMChapterDetails serializeToXDM no properties returns empty map`() {
+        val chapterDetails = XDMChapterDetails()
+        val xdm = chapterDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMCustomMetadata serializeToXDM all properties`() {
+        val customMetadata = XDMCustomMetadata()
+        customMetadata.name = "testName"
+        customMetadata.value = "testValue"
+
+        val xdm = customMetadata.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "name" to "testName",
+            "value" to "testValue"
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMCustomMetadata::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMCustomMetadata serializeToXDM no properties returns empty map`() {
+        val customMetadata = XDMCustomMetadata()
+        val xdm = customMetadata.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMErrorDetails serializeToXDM all properties`() {
+        val errorDetails = XDMErrorDetails()
+        errorDetails.name = "testName"
+        errorDetails.source = "testSource"
+
+        val xdm = errorDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "name" to "testName",
+            "source" to "testSource"
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMErrorDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMErrorDetails serializeToXDM no properties returns empty map`() {
+        val errorDetails = XDMErrorDetails()
+        val xdm = errorDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMPlayerStateData serializeToXDM all properties`() {
+        val playerStateData = XDMPlayerStateData()
+        playerStateData.name = "testName"
+
+        val xdm = playerStateData.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "name" to "testName"
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMPlayerStateData::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMPlayerStateData serializeToXDM no properties returns empty map`() {
+        val playerStateData = XDMPlayerStateData()
+        val xdm = playerStateData.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMQoeDataDetails serializeToXDM all properties`() {
+        val qoeDataDetails = XDMQoeDataDetails()
+        qoeDataDetails.bitrate = 128
+        qoeDataDetails.droppedFrames = 10
+        qoeDataDetails.framesPerSecond = 59
+        qoeDataDetails.timeToStart = 5
+
+        val xdm = qoeDataDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "bitrate" to 128L,
+            "droppedFrames" to 10L,
+            "framesPerSecond" to 59L,
+            "timeToStart" to 5L
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMQoeDataDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMQoeDataDetails serializeToXDM no properties returns empty map`() {
+        val qoeDataDetails = XDMQoeDataDetails()
+        val xdm = qoeDataDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMSessionDetails serializeToXDM all properties`() {
+        val sessionDetails = XDMSessionDetails()
+        sessionDetails.contentType = "vod"
+        sessionDetails.name = "id"
+        sessionDetails.friendlyName = "name"
+        sessionDetails.hasResume = false
+        sessionDetails.length = 30
+        sessionDetails.streamType = XDMStreamType.VIDEO
+
+        sessionDetails.channel = "test_channel"
+        sessionDetails.playerName = "test_playerName"
+        sessionDetails.appVersion = "test_appVersion"
+
+        // Audio Standard Metadata
+        sessionDetails.album = "test_album"
+        sessionDetails.artist = "test_artist"
+        sessionDetails.author = "test_author"
+        sessionDetails.label = "test_label"
+        sessionDetails.publisher = "test_publisher"
+        sessionDetails.station = "test_station"
+
+        // Video Standard Metadata
+        sessionDetails.adLoad = "preroll"
+        sessionDetails.authorized = "false"
+        sessionDetails.assetID = "test_assetID"
+        sessionDetails.dayPart = "evening"
+        sessionDetails.episode = "1"
+        sessionDetails.feed = "test_feed"
+        sessionDetails.firstAirDate = "test_firstAirDate"
+        sessionDetails.firstDigitalDate = "test_firstAirDigitalDate"
+        sessionDetails.genre = "test_genre"
+        sessionDetails.mvpd = "test_mvpd"
+        sessionDetails.network = "test_network"
+        sessionDetails.originator = "test_originator"
+        sessionDetails.rating = "test_rating"
+        sessionDetails.season = "1"
+        sessionDetails.segment = "test_segment"
+        sessionDetails.show = "test_show"
+        sessionDetails.showType = "test_showType"
+        sessionDetails.streamFormat = "test_streamFormat"
+
+        val xdm = sessionDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "contentType" to "vod",
+            "name" to "id",
+            "friendlyName" to "name",
+            "hasResume" to false,
+            "length" to 30L,
+            "streamType" to XDMStreamType.VIDEO.value,
+            "channel" to "test_channel",
+            "playerName" to "test_playerName",
+            "appVersion" to "test_appVersion",
+            "album" to "test_album",
+            "artist" to "test_artist",
+            "author" to "test_author",
+            "label" to "test_label",
+            "publisher" to "test_publisher",
+            "station" to "test_station",
+            "adLoad" to "preroll",
+            "authorized" to "false",
+            "assetID" to "test_assetID",
+            "dayPart" to "evening",
+            "episode" to "1",
+            "feed" to "test_feed",
+            "firstAirDate" to "test_firstAirDate",
+            "firstDigitalDate" to "test_firstAirDigitalDate",
+            "genre" to "test_genre",
+            "mvpd" to "test_mvpd",
+            "network" to "test_network",
+            "originator" to "test_originator",
+            "rating" to "test_rating",
+            "season" to "1",
+            "segment" to "test_segment",
+            "show" to "test_show",
+            "showType" to "test_showType",
+            "streamFormat" to "test_streamFormat"
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMSessionDetails::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMSessionDetails serializeToXDM video properties`() {
+        val sessionDetails = XDMSessionDetails()
+        sessionDetails.contentType = "vod"
+        sessionDetails.name = "id"
+        sessionDetails.friendlyName = "name"
+        sessionDetails.hasResume = false
+        sessionDetails.length = 30
+        sessionDetails.streamType = XDMStreamType.VIDEO
+
+        sessionDetails.channel = "test_channel"
+        sessionDetails.playerName = "test_playerName"
+        sessionDetails.appVersion = "test_appVersion"
+
+        // Video Standard Metadata
+        sessionDetails.adLoad = "preroll"
+        sessionDetails.authorized = "false"
+        sessionDetails.assetID = "test_assetID"
+        sessionDetails.dayPart = "evening"
+        sessionDetails.episode = "1"
+        sessionDetails.feed = "test_feed"
+        sessionDetails.firstAirDate = "test_firstAirDate"
+        sessionDetails.firstDigitalDate = "test_firstAirDigitalDate"
+        sessionDetails.genre = "test_genre"
+        sessionDetails.mvpd = "test_mvpd"
+        sessionDetails.network = "test_network"
+        sessionDetails.originator = "test_originator"
+        sessionDetails.rating = "test_rating"
+        sessionDetails.season = "1"
+        sessionDetails.segment = "test_segment"
+        sessionDetails.show = "test_show"
+        sessionDetails.showType = "test_showType"
+        sessionDetails.streamFormat = "test_streamFormat"
+
+        val xdm = sessionDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "contentType" to "vod",
+            "name" to "id",
+            "friendlyName" to "name",
+            "hasResume" to false,
+            "length" to 30L,
+            "streamType" to XDMStreamType.VIDEO.value,
+            "channel" to "test_channel",
+            "playerName" to "test_playerName",
+            "appVersion" to "test_appVersion",
+            "adLoad" to "preroll",
+            "authorized" to "false",
+            "assetID" to "test_assetID",
+            "dayPart" to "evening",
+            "episode" to "1",
+            "feed" to "test_feed",
+            "firstAirDate" to "test_firstAirDate",
+            "firstDigitalDate" to "test_firstAirDigitalDate",
+            "genre" to "test_genre",
+            "mvpd" to "test_mvpd",
+            "network" to "test_network",
+            "originator" to "test_originator",
+            "rating" to "test_rating",
+            "season" to "1",
+            "segment" to "test_segment",
+            "show" to "test_show",
+            "showType" to "test_showType",
+            "streamFormat" to "test_streamFormat"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMSessionDetails serializeToXDM audio properties`() {
+        val sessionDetails = XDMSessionDetails()
+        sessionDetails.contentType = "aod"
+        sessionDetails.name = "id"
+        sessionDetails.friendlyName = "name"
+        sessionDetails.hasResume = false
+        sessionDetails.length = 30
+        sessionDetails.streamType = XDMStreamType.AUDIO
+
+        sessionDetails.channel = "test_channel"
+        sessionDetails.playerName = "test_playerName"
+        sessionDetails.appVersion = "test_appVersion"
+
+        // Audio Standard Metadata
+        sessionDetails.album = "test_album"
+        sessionDetails.artist = "test_artist"
+        sessionDetails.author = "test_author"
+        sessionDetails.label = "test_label"
+        sessionDetails.publisher = "test_publisher"
+        sessionDetails.station = "test_station"
+
+        val xdm = sessionDetails.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "contentType" to "aod",
+            "name" to "id",
+            "friendlyName" to "name",
+            "hasResume" to false,
+            "length" to 30L,
+            "streamType" to XDMStreamType.AUDIO.value,
+            "channel" to "test_channel",
+            "playerName" to "test_playerName",
+            "appVersion" to "test_appVersion",
+            "album" to "test_album",
+            "artist" to "test_artist",
+            "author" to "test_author",
+            "label" to "test_label",
+            "publisher" to "test_publisher",
+            "station" to "test_station"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMSessionDetails serializeToXDM no properties returns empty map`() {
+        val sessionDetails = XDMSessionDetails()
+        val xdm = sessionDetails.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM all properties`() {
+        val (advertisingDetails, expectedAdvertisingDetails) = getSampleAdvertisingDetails()
+        val (advertisingPodDetails, expectedAdvertisingPodDetails) = getSampleAdvertisingPodDetails()
+        val (chapterDetails, expectedChapterDetails) = getSampleChapterDetails()
+        val (customMetadata, expectedCustomMetadata) = getSampleCustomMetadata()
+        val (errorDetails, expectedErrorDetails) = getSampleErrorDetails()
+        val (qoeDataDetails, expectedQoeDataDetails) = getSampleQoeDataDetails()
+        val (sessionDetails, expectedSessionDetails) = getSampleSessionDetails()
+        val (playerStateData, expectedPlayerStateData) = getSamplePlayerStateData()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.advertisingDetails = advertisingDetails
+        mediaCollection.advertisingPodDetails = advertisingPodDetails
+        mediaCollection.chapterDetails = chapterDetails
+        mediaCollection.customMetadata = customMetadata
+        mediaCollection.errorDetails = errorDetails
+        mediaCollection.playHead = 123
+        mediaCollection.qoeDataDetails = qoeDataDetails
+        mediaCollection.sessionDetails = sessionDetails
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        mediaCollection.statesStart = playerStateData
+        mediaCollection.statesEnd = playerStateData
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "advertisingDetails" to expectedAdvertisingDetails,
+            "advertisingPodDetails" to expectedAdvertisingPodDetails,
+            "chapterDetails" to expectedChapterDetails,
+            "customMetadata" to expectedCustomMetadata,
+            "errorDetails" to expectedErrorDetails,
+            "playHead" to 123L,
+            "qoeDataDetails" to expectedQoeDataDetails,
+            "sessionDetails" to expectedSessionDetails,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
+            "statesStart" to expectedPlayerStateData,
+            "statesEnd" to expectedPlayerStateData
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMMediaCollection::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM SessionStart properties`() {
+        val (sessionDetails, expectedSessionDetails) = getSampleSessionDetails()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playHead = 0
+        mediaCollection.sessionDetails = sessionDetails
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "playHead" to 0L,
+            "sessionDetails" to expectedSessionDetails,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM AdBreakStart properties`() {
+        val (advertisingPodDetails, expectedAdvertisingPodDetails) = getSampleAdvertisingPodDetails()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.advertisingPodDetails = advertisingPodDetails
+        mediaCollection.playHead = 0
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "advertisingPodDetails" to expectedAdvertisingPodDetails,
+            "playHead" to 0L,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM AdStart properties`() {
+        val (advertisingDetails, expectedAdvertisingDetails) = getSampleAdvertisingDetails()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.advertisingDetails = advertisingDetails
+        mediaCollection.playHead = 123
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "advertisingDetails" to expectedAdvertisingDetails,
+            "playHead" to 123L,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM ChapterStart properties`() {
+        val (chapterDetails, expectedChapterDetails) = getSampleChapterDetails()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.chapterDetails = chapterDetails
+        mediaCollection.playHead = 123
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "chapterDetails" to expectedChapterDetails,
+            "playHead" to 123L,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM StateStart properties`() {
+        val (playerStateData, expectedPlayerStateData) = getSamplePlayerStateData()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playHead = 123
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        mediaCollection.statesStart = playerStateData
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "playHead" to 123L,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
+            "statesStart" to expectedPlayerStateData
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM StateEnd properties`() {
+        val (playerStateData, expectedPlayerStateData) = getSamplePlayerStateData()
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playHead = 123
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        mediaCollection.statesEnd = playerStateData
+
+        val xdm = mediaCollection.serializeToXDM()
+        val expected = mapOf<String, Any>(
+            "playHead" to 123L,
+            "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
+            "statesEnd" to expectedPlayerStateData
+        )
+
+        assertEquals(expected, xdm)
+    }
+
+    @Test
+    fun `XDMMediaCollection serializeToXDM no properties returns empty map`() {
+        val mediaCollection = XDMMediaCollection()
+        val xdm = mediaCollection.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    private fun getSampleAdvertisingDetails(): Pair<XDMAdvertisingDetails, Map<String, Any>> {
+        val advertisingDetails = XDMAdvertisingDetails()
+        advertisingDetails.name = "id"
+        advertisingDetails.friendlyName = "name"
+        advertisingDetails.length = 10
+        advertisingDetails.podPosition = 1
+        advertisingDetails.playerName = "testPlayer"
+        advertisingDetails.advertiser = "testAdvertiser"
+        advertisingDetails.campaignID = "testCampaignId"
+        advertisingDetails.creativeID = "testCreativeId"
+        advertisingDetails.creativeURL = "testCreativeUrl"
+        advertisingDetails.placementID = "testPlacementId"
+        advertisingDetails.siteID = "testSiteId"
+
+        val expected = mapOf<String, Any>(
+            "name" to "id",
+            "friendlyName" to "name",
+            "length" to 10L,
+            "podPosition" to 1L,
+            "playerName" to "testPlayer",
+            "advertiser" to "testAdvertiser",
+            "campaignID" to "testCampaignId",
+            "creativeID" to "testCreativeId",
+            "creativeURL" to "testCreativeUrl",
+            "placementID" to "testPlacementId",
+            "siteID" to "testSiteId"
+        )
+
+        return advertisingDetails to expected
+    }
+
+    private fun getSampleAdvertisingPodDetails(): Pair<XDMAdvertisingPodDetails, Map<String, Any>> {
+        val advertisingPodDetails = XDMAdvertisingPodDetails()
+        advertisingPodDetails.friendlyName = "name"
+        advertisingPodDetails.index = 1
+        advertisingPodDetails.offset = 2
+
+        val expected = mapOf<String, Any>(
+            "friendlyName" to "name",
+            "index" to 1L,
+            "offset" to 2L
+        )
+
+        return advertisingPodDetails to expected
+    }
+
+    private fun getSampleChapterDetails(): Pair<XDMChapterDetails, Map<String, Any>> {
+        val chapterDetails = XDMChapterDetails()
+        chapterDetails.friendlyName = "test friendly name"
+        chapterDetails.index = 1
+        chapterDetails.length = 10
+        chapterDetails.offset = 2
+
+        val expected = mapOf<String, Any>(
+            "friendlyName" to "test friendly name",
+            "index" to 1L,
+            "length" to 10L,
+            "offset" to 2L
+        )
+
+        return chapterDetails to expected
+    }
+
+    private fun getSampleCustomMetadata(): Pair<List<XDMCustomMetadata>, List<Map<String, Any>>> {
+        val customMetadata1 = XDMCustomMetadata()
+        customMetadata1.name = "customOne"
+        customMetadata1.value = "valueOne"
+
+        val customMetadata2 = XDMCustomMetadata()
+        customMetadata2.name = "customTwo"
+        customMetadata2.value = "valueTwo"
+
+        val expected = listOf(
+            mapOf<String, Any>(
+                "name" to "customOne",
+                "value" to "valueOne"
+            ),
+            mapOf<String, Any>(
+                "name" to "customTwo",
+                "value" to "valueTwo"
+            )
+        )
+
+        return listOf(customMetadata1, customMetadata2) to expected
+    }
+
+    private fun getSampleErrorDetails(): Pair<XDMErrorDetails, Map<String, Any>> {
+        val errorDetails = XDMErrorDetails()
+        errorDetails.name = "testName"
+        errorDetails.source = "testSource"
+
+        val expected = mapOf<String, Any>(
+            "name" to "testName",
+            "source" to "testSource"
+        )
+
+        return errorDetails to expected
+    }
+
+    private fun getSampleQoeDataDetails(): Pair<XDMQoeDataDetails, Map<String, Any>> {
+        val qoeDataDetails = XDMQoeDataDetails()
+        qoeDataDetails.bitrate = 128
+        qoeDataDetails.droppedFrames = 10
+        qoeDataDetails.framesPerSecond = 59
+        qoeDataDetails.timeToStart = 5
+
+        val expected = mapOf<String, Any>(
+            "bitrate" to 128L,
+            "droppedFrames" to 10L,
+            "framesPerSecond" to 59L,
+            "timeToStart" to 5L
+        )
+
+        return qoeDataDetails to expected
+    }
+
+    private fun getSampleSessionDetails(): Pair<XDMSessionDetails, Map<String, Any>> {
+        val sessionDetails = XDMSessionDetails()
+        sessionDetails.contentType = "aod"
+        sessionDetails.name = "id"
+        sessionDetails.friendlyName = "name"
+        sessionDetails.hasResume = false
+        sessionDetails.length = 30
+        sessionDetails.streamType = XDMStreamType.AUDIO
+
+        sessionDetails.channel = "test_channel"
+        sessionDetails.playerName = "test_playerName"
+        sessionDetails.appVersion = "test_appVersion"
+
+        // Audio Standard Metadata
+        sessionDetails.album = "test_album"
+        sessionDetails.artist = "test_artist"
+        sessionDetails.author = "test_author"
+        sessionDetails.label = "test_label"
+        sessionDetails.publisher = "test_publisher"
+        sessionDetails.station = "test_station"
+
+        val expected = mapOf<String, Any>(
+            "contentType" to "aod",
+            "name" to "id",
+            "friendlyName" to "name",
+            "hasResume" to false,
+            "length" to 30L,
+            "streamType" to XDMStreamType.AUDIO.value,
+            "channel" to "test_channel",
+            "playerName" to "test_playerName",
+            "appVersion" to "test_appVersion",
+            "album" to "test_album",
+            "artist" to "test_artist",
+            "author" to "test_author",
+            "label" to "test_label",
+            "publisher" to "test_publisher",
+            "station" to "test_station"
+        )
+
+        return sessionDetails to expected
+    }
+
+    private fun getSamplePlayerStateData(): Pair<List<XDMPlayerStateData>, List<Map<String, Any>>> {
+        val muteState = XDMPlayerStateData()
+        muteState.name = "mute"
+
+        val fullscreenState = XDMPlayerStateData()
+        fullscreenState.name = "fullscreen"
+
+        val expected = listOf(
+            mapOf<String, Any>(
+                "name" to "mute"
+            ),
+            mapOf<String, Any>(
+                "name" to "fullscreen"
+            )
+        )
+
+        return listOf(muteState, fullscreenState) to expected
+    }
+}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -449,7 +449,7 @@ class XDMPropertyTests {
         mediaCollection.chapterDetails = chapterDetails
         mediaCollection.customMetadata = customMetadata
         mediaCollection.errorDetails = errorDetails
-        mediaCollection.playHead = 123
+        mediaCollection.playhead = 123
         mediaCollection.qoeDataDetails = qoeDataDetails
         mediaCollection.sessionDetails = sessionDetails
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -463,7 +463,7 @@ class XDMPropertyTests {
             "chapterDetails" to expectedChapterDetails,
             "customMetadata" to expectedCustomMetadata,
             "errorDetails" to expectedErrorDetails,
-            "playHead" to 123L,
+            "playhead" to 123L,
             "qoeDataDetails" to expectedQoeDataDetails,
             "sessionDetails" to expectedSessionDetails,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
@@ -481,13 +481,13 @@ class XDMPropertyTests {
         val (sessionDetails, expectedSessionDetails) = getSampleSessionDetails()
 
         val mediaCollection = XDMMediaCollection()
-        mediaCollection.playHead = 0
+        mediaCollection.playhead = 0
         mediaCollection.sessionDetails = sessionDetails
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
-            "playHead" to 0L,
+            "playhead" to 0L,
             "sessionDetails" to expectedSessionDetails,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         )
@@ -501,13 +501,13 @@ class XDMPropertyTests {
 
         val mediaCollection = XDMMediaCollection()
         mediaCollection.advertisingPodDetails = advertisingPodDetails
-        mediaCollection.playHead = 0
+        mediaCollection.playhead = 0
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
             "advertisingPodDetails" to expectedAdvertisingPodDetails,
-            "playHead" to 0L,
+            "playhead" to 0L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         )
 
@@ -520,13 +520,13 @@ class XDMPropertyTests {
 
         val mediaCollection = XDMMediaCollection()
         mediaCollection.advertisingDetails = advertisingDetails
-        mediaCollection.playHead = 123
+        mediaCollection.playhead = 123
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
             "advertisingDetails" to expectedAdvertisingDetails,
-            "playHead" to 123L,
+            "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         )
 
@@ -539,13 +539,13 @@ class XDMPropertyTests {
 
         val mediaCollection = XDMMediaCollection()
         mediaCollection.chapterDetails = chapterDetails
-        mediaCollection.playHead = 123
+        mediaCollection.playhead = 123
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
             "chapterDetails" to expectedChapterDetails,
-            "playHead" to 123L,
+            "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         )
 
@@ -557,13 +557,13 @@ class XDMPropertyTests {
         val (playerStateData, expectedPlayerStateData) = getSamplePlayerStateData()
 
         val mediaCollection = XDMMediaCollection()
-        mediaCollection.playHead = 123
+        mediaCollection.playhead = 123
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         mediaCollection.statesStart = playerStateData
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
-            "playHead" to 123L,
+            "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
             "statesStart" to expectedPlayerStateData
         )
@@ -576,13 +576,13 @@ class XDMPropertyTests {
         val (playerStateData, expectedPlayerStateData) = getSamplePlayerStateData()
 
         val mediaCollection = XDMMediaCollection()
-        mediaCollection.playHead = 123
+        mediaCollection.playhead = 123
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         mediaCollection.statesEnd = playerStateData
 
         val xdm = mediaCollection.serializeToXDM()
         val expected = mapOf<String, Any>(
-            "playHead" to 123L,
+            "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
             "statesEnd" to expectedPlayerStateData
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add XDM data model classes.

Each XDM class is a Kotlin data class containing all the required properties plus a single `serializeToXDM` function.
Each XDM class extends from the `XDMProperty` interface which provides the abstract `serializeToXDM` function, plus a helper function to serialize a list of classes to XDM.
A single unit test class, `XDMPropertyTests`, is added to test all the classes. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
