### PR TITLE
Add MediaSession and MediaRealTimeSession classes

### DIFF
--- a/code/edgemedia/build.gradle
+++ b/code/edgemedia/build.gradle
@@ -63,7 +63,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:4.5.1"
     testImplementation 'org.mockito:mockito-inline:4.5.1'
-    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.0'
+    testImplementation 'org.jetbrains.kotlin:kotlin-reflect:1.7.20'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
     //noinspection GradleDependency
     testImplementation 'org.json:json:20180813'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -42,6 +42,9 @@ final class MediaInternalConstants {
         static final String REQUEST_EVENT_ID = "requestEventId";
         static final String PAYLOAD = "payload";
         static final String SESSION_ID = "sessionId";
+        static final long ERROR_CODE_400 = 400L;
+        static final String ERROR_TYPE_VA_EDGE_400 =
+                "https://ns.adobe.com/aep/errors/va-edge-0400-400";
 
         private Edge() {}
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -21,9 +21,8 @@ final class MediaInternalConstants {
     static final class Media {
         // TODO - use EventType.EDGE_MEDIA when released
         static final String EVENT_TYPE_EDGE_MEDIA = "com.adobe.eventType.edgeMedia";
-        static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.requestTracker";
+        static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.createTracker";
         static final String EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventSource.trackMedia";
-        static final String EVENT_SOURCE_SESSION_CREATED = "com.adobe.eventSource.sessionCreated";
         static final String EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session";
 
         private Media() {}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -138,7 +138,7 @@ internal class MediaRealTimeSession(
         while (events.isNotEmpty()) {
             val event = events.first()
 
-            if (event.xdmData?.eventType != XDMMediaEventType.SESSION_START && mediaBackendSessionId == null) {
+            if (event.xdmData.eventType != XDMMediaEventType.SESSION_START && mediaBackendSessionId == null) {
                 Log.trace(LOG_TAG, sourceTag, "processMediaEvents - Session $id: Exiting as the media session id is unavailable, will retry later.")
                 return
             }
@@ -155,16 +155,16 @@ internal class MediaRealTimeSession(
      * Attaches the required [MediaState] information to the given [XDMMediaEvent].
      */
     private fun attachMediaStateInfo(event: XDMMediaEvent) {
-        if (XDMMediaEventType.SESSION_START == event.xdmData?.eventType) {
-            event.xdmData?.mediaCollection?.sessionDetails?.playerName = state.mediaPlayerName
-            event.xdmData?.mediaCollection?.sessionDetails?.appVersion = state.mediaAppVersion
-            if (event.xdmData?.mediaCollection?.sessionDetails?.channel == null) {
-                event.xdmData?.mediaCollection?.sessionDetails?.channel = state.mediaChannel
+        if (XDMMediaEventType.SESSION_START == event.xdmData.eventType) {
+            event.xdmData.mediaCollection?.sessionDetails?.playerName = state.mediaPlayerName
+            event.xdmData.mediaCollection?.sessionDetails?.appVersion = state.mediaAppVersion
+            if (event.xdmData.mediaCollection?.sessionDetails?.channel == null) {
+                event.xdmData.mediaCollection?.sessionDetails?.channel = state.mediaChannel
             }
         } else {
-            event.xdmData?.mediaCollection?.sessionID = mediaBackendSessionId
-            if (XDMMediaEventType.AD_START == event.xdmData?.eventType) {
-                event.xdmData?.mediaCollection?.advertisingDetails?.playerName = state.mediaPlayerName
+            event.xdmData.mediaCollection?.sessionID = mediaBackendSessionId
+            if (XDMMediaEventType.AD_START == event.xdmData.eventType) {
+                event.xdmData.mediaCollection?.advertisingDetails?.playerName = state.mediaPlayerName
             }
         }
     }
@@ -173,7 +173,7 @@ internal class MediaRealTimeSession(
      * Dispatches a experience event to the Edge extension to send to the media backend service.
      */
     private fun dispatchExperienceEvent(mediaEvent: XDMMediaEvent, dispatcher: (event: Event) -> Unit) {
-        val eventType = mediaEvent.xdmData?.eventType
+        val eventType = mediaEvent.xdmData.eventType
         val eventName = if (eventType != null) XDMMediaEventType.getTypeString(eventType) else ""
         val edgeEvent = Event.Builder(
             "Edge Media - $eventName",
@@ -183,7 +183,7 @@ internal class MediaRealTimeSession(
             .setEventData(mediaEvent.serializeToXDM())
             .build()
 
-        if (XDMMediaEventType.SESSION_START == mediaEvent.xdmData?.eventType) {
+        if (XDMMediaEventType.SESSION_START == mediaEvent.xdmData.eventType) {
             sessionStartEdgeRequestId = edgeEvent.uniqueIdentifier
         }
 

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -15,6 +15,7 @@ import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.edge.media.internal.MediaInternalConstants.LOG_TAG
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
 import com.adobe.marketing.mobile.services.Log
@@ -26,10 +27,7 @@ internal class MediaRealTimeSession(
     dispatchHandler: (Event) -> Unit
 ) : MediaSession(id, state, dispatchHandler) {
 
-    companion object {
-        private const val LOG_TAG = MediaInternalConstants.LOG_TAG
-        private const val SOURCE_TAG = "MediaRealTimeSession"
-    }
+    private val sourceTag = "MediaRealTimeSession" // Log source tag
 
     // Session id for this session, set when handling sessionStart response from backend media server
     @VisibleForTesting
@@ -120,7 +118,7 @@ internal class MediaRealTimeSession(
         }
 
         if (statusCode == MediaInternalConstants.Edge.ERROR_CODE_400 && errorType == MediaInternalConstants.Edge.ERROR_TYPE_VA_EDGE_400) {
-            Log.warning(LOG_TAG, SOURCE_TAG, "handleErrorResponse - Session $id: Aborting session as error occurred while dispatching session start request. $data")
+            Log.warning(LOG_TAG, sourceTag, "handleErrorResponse - Session $id: Aborting session as error occurred while dispatching session start request. $data")
             abort(sessionEndHandler)
         }
     }
@@ -133,7 +131,7 @@ internal class MediaRealTimeSession(
      */
     private fun processMediaEvents() {
         if (!state.isValid) {
-            Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Exiting as the required configuration is missing. Verify 'media.channel' and 'media.playerName' are configured.")
+            Log.trace(LOG_TAG, sourceTag, "processMediaEvents - Session $id: Exiting as the required configuration is missing. Verify 'media.channel' and 'media.playerName' are configured.")
             return
         }
 
@@ -141,7 +139,7 @@ internal class MediaRealTimeSession(
             val event = events.first()
 
             if (event.xdmData?.eventType != XDMMediaEventType.SESSION_START && mediaBackendSessionId == null) {
-                Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Exiting as the media session id is unavailable, will retry later.")
+                Log.trace(LOG_TAG, sourceTag, "processMediaEvents - Session $id: Exiting as the media session id is unavailable, will retry later.")
                 return
             }
 

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -133,8 +133,10 @@ internal class MediaRealTimeSession(
     }
 
     private fun dispatchExperienceEvent(mediaEvent: XDMMediaEvent, dispatcher: (event: Event) -> Unit) {
+        val eventType = mediaEvent.xdmData?.eventType
+        val eventName = if (eventType != null) XDMMediaEventType.getTypeString(eventType) else ""
         val edgeEvent = Event.Builder(
-            "Edge Media ${mediaEvent.xdmData?.eventType?.value}",
+            "Edge Media - $eventName",
             EventType.EDGE,
             EventSource.REQUEST_CONTENT
         )

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -103,7 +103,7 @@ internal class MediaRealTimeSession(
             val event = events.first()
 
             if (event.xdmData?.eventType != XDMMediaEventType.SESSION_START && mediaBackendSessionId == null) {
-                Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Existing as the media session id is unavailable, will retry later.")
+                Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Exiting as the media session id is unavailable, will retry later.")
                 return
             }
 

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -1,0 +1,150 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
+import com.adobe.marketing.mobile.services.Log
+import com.adobe.marketing.mobile.util.StringUtils
+
+internal class MediaRealTimeSession(
+    id: String,
+    trackerSessionId: String?,
+    state: MediaState,
+    dispatchHandler: (Event) -> Unit
+) : MediaSession(id, trackerSessionId, state, dispatchHandler) {
+
+    companion object {
+        private const val LOG_TAG = MediaInternalConstants.LOG_TAG
+        private const val SOURCE_TAG = "MediaRealTimeSession"
+    }
+
+    private var mediaBackendSessionId: String? = null
+        set(value) {
+            field = if (!StringUtils.isNullOrEmpty(value)) value else null
+        }
+    private var sessionStartEdgeRequestId: String? = null
+    private val events: MutableList<XDMMediaEvent> = mutableListOf()
+
+    override fun handleMediaStateUpdate() {
+        processMediaEvents()
+    }
+
+    override fun handleSessionEnd() {
+        processMediaEvents()
+        if (events.isEmpty()) {
+            sessionEndHandler()
+        }
+    }
+
+    override fun handleSessionAbort() {
+        events.clear()
+        sessionEndHandler()
+    }
+
+    override fun handleQueueEvent(event: XDMMediaEvent) {
+        if (!isSessionActive) {
+            return
+        }
+
+        events.add(event)
+        processMediaEvents()
+    }
+
+    override fun handleSessionUpdate(requestEventId: String, backendSessionId: String?) {
+        if (requestEventId != sessionStartEdgeRequestId) {
+            return
+        }
+
+        mediaBackendSessionId = backendSessionId
+        if (mediaBackendSessionId != null) {
+            processMediaEvents()
+        } else {
+            abort(sessionEndHandler)
+        }
+    }
+
+    override fun handleErrorResponse(requestEventId: String, data: Map<String, Any>) {
+        if (requestEventId != sessionStartEdgeRequestId) {
+            return
+        }
+
+        val statusCode = data["status"]
+        val errorType = data["type"]
+
+        if (statusCode !is Long || errorType !is String) {
+            return
+        }
+
+        if (statusCode == MediaInternalConstants.Edge.ERROR_CODE_400 && statusCode == MediaInternalConstants.Edge.ERROR_TYPE_VA_EDGE_400) {
+            Log.warning(LOG_TAG, SOURCE_TAG, "handleErrorResponse - Session $id: Aborting session as error occurred while dispatching session start request. $data")
+            abort(sessionEndHandler)
+        }
+    }
+
+    private fun processMediaEvents() {
+        if (!state.isValid) {
+            Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Exiting as the required configuration is missing. Verify 'media.channel' and 'media.playerName' are configured.")
+            return
+        }
+
+        while (events.isNotEmpty()) {
+            val event = events.first()
+
+            if (event.xdmData?.eventType != XDMMediaEventType.SESSION_START && mediaBackendSessionId == null) {
+                Log.trace(LOG_TAG, SOURCE_TAG, "processMediaEvents - Session $id: Existing as the media session id is unavailable, will retry later.")
+                return
+            }
+
+            attachMediaStateInfo(event)
+
+            dispatchExperienceEvent(event, dispatchHandler)
+
+            events.removeFirst()
+        }
+    }
+
+    private fun attachMediaStateInfo(event: XDMMediaEvent) {
+        if (XDMMediaEventType.SESSION_START == event.xdmData?.eventType) {
+            event.xdmData?.mediaCollection?.sessionDetails?.playerName = state.mediaPlayerName
+            event.xdmData?.mediaCollection?.sessionDetails?.appVersion = state.mediaAppVersion
+            if (event.xdmData?.mediaCollection?.sessionDetails?.channel == null) {
+                event.xdmData?.mediaCollection?.sessionDetails?.channel = state.mediaChannel
+            }
+        } else {
+            event.xdmData?.mediaCollection?.sessionID = mediaBackendSessionId
+            if (XDMMediaEventType.AD_START == event.xdmData?.eventType) {
+                event.xdmData?.mediaCollection?.advertisingDetails?.playerName = state.mediaPlayerName
+            }
+        }
+    }
+
+    private fun dispatchExperienceEvent(mediaEvent: XDMMediaEvent, dispatcher: (event: Event) -> Unit) {
+        val edgeEvent = Event.Builder(
+            "Edge Media ${mediaEvent.xdmData?.eventType?.value}",
+            EventType.EDGE,
+            EventSource.REQUEST_CONTENT
+        )
+            .setEventData(mediaEvent.serializeToXDM())
+            .build()
+
+        if (XDMMediaEventType.SESSION_START == mediaEvent.xdmData?.eventType) {
+            sessionStartEdgeRequestId = edgeEvent.uniqueIdentifier
+        }
+
+        // Dispatch the media event to the eventhub to be sent to the backend service by the edge extension
+        dispatcher(edgeEvent)
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -156,15 +156,15 @@ internal class MediaRealTimeSession(
      */
     private fun attachMediaStateInfo(event: XDMMediaEvent) {
         if (XDMMediaEventType.SESSION_START == event.xdmData.eventType) {
-            event.xdmData.mediaCollection?.sessionDetails?.playerName = state.mediaPlayerName
-            event.xdmData.mediaCollection?.sessionDetails?.appVersion = state.mediaAppVersion
-            if (event.xdmData.mediaCollection?.sessionDetails?.channel == null) {
-                event.xdmData.mediaCollection?.sessionDetails?.channel = state.mediaChannel
+            event.xdmData.mediaCollection.sessionDetails?.playerName = state.mediaPlayerName
+            event.xdmData.mediaCollection.sessionDetails?.appVersion = state.mediaAppVersion
+            if (event.xdmData.mediaCollection.sessionDetails?.channel == null) {
+                event.xdmData.mediaCollection.sessionDetails?.channel = state.mediaChannel
             }
         } else {
-            event.xdmData.mediaCollection?.sessionID = mediaBackendSessionId
+            event.xdmData.mediaCollection.sessionID = mediaBackendSessionId
             if (XDMMediaEventType.AD_START == event.xdmData.eventType) {
-                event.xdmData.mediaCollection?.advertisingDetails?.playerName = state.mediaPlayerName
+                event.xdmData.mediaCollection.advertisingDetails?.playerName = state.mediaPlayerName
             }
         }
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal
 
+import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
@@ -30,12 +31,17 @@ internal class MediaRealTimeSession(
         private const val SOURCE_TAG = "MediaRealTimeSession"
     }
 
-    private var mediaBackendSessionId: String? = null
+    @VisibleForTesting
+    internal var mediaBackendSessionId: String? = null
         set(value) {
             field = if (!StringUtils.isNullOrEmpty(value)) value else null
         }
-    private var sessionStartEdgeRequestId: String? = null
-    private val events: MutableList<XDMMediaEvent> = mutableListOf()
+
+    @VisibleForTesting
+    internal var sessionStartEdgeRequestId: String? = null
+
+    @VisibleForTesting
+    internal val events: MutableList<XDMMediaEvent> = mutableListOf()
 
     override fun handleMediaStateUpdate() {
         processMediaEvents()
@@ -54,10 +60,6 @@ internal class MediaRealTimeSession(
     }
 
     override fun handleQueueEvent(event: XDMMediaEvent) {
-        if (!isSessionActive) {
-            return
-        }
-
         events.add(event)
         processMediaEvents()
     }
@@ -87,7 +89,7 @@ internal class MediaRealTimeSession(
             return
         }
 
-        if (statusCode == MediaInternalConstants.Edge.ERROR_CODE_400 && statusCode == MediaInternalConstants.Edge.ERROR_TYPE_VA_EDGE_400) {
+        if (statusCode == MediaInternalConstants.Edge.ERROR_CODE_400 && errorType == MediaInternalConstants.Edge.ERROR_TYPE_VA_EDGE_400) {
             Log.warning(LOG_TAG, SOURCE_TAG, "handleErrorResponse - Session $id: Aborting session as error occurred while dispatching session start request. $data")
             abort(sessionEndHandler)
         }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -173,10 +173,8 @@ internal class MediaRealTimeSession(
      * Dispatches a experience event to the Edge extension to send to the media backend service.
      */
     private fun dispatchExperienceEvent(mediaEvent: XDMMediaEvent, dispatcher: (event: Event) -> Unit) {
-        val eventType = mediaEvent.xdmData.eventType
-        val eventName = if (eventType != null) XDMMediaEventType.getTypeString(eventType) else ""
         val edgeEvent = Event.Builder(
-            "Edge Media - $eventName",
+            "Edge Media - ${XDMMediaEventType.getTypeString(mediaEvent.xdmData.eventType)}",
             EventType.EDGE,
             EventSource.REQUEST_CONTENT
         )

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSession.kt
@@ -21,10 +21,9 @@ import com.adobe.marketing.mobile.util.StringUtils
 
 internal class MediaRealTimeSession(
     id: String,
-    trackerSessionId: String?,
     state: MediaState,
     dispatchHandler: (Event) -> Unit
-) : MediaSession(id, trackerSessionId, state, dispatchHandler) {
+) : MediaSession(id, state, dispatchHandler) {
 
     companion object {
         private const val LOG_TAG = MediaInternalConstants.LOG_TAG

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -23,10 +23,10 @@ import com.adobe.marketing.mobile.services.Log
  * @property dispatchHandler closure for dispatching [Event]s
  */
 internal abstract class MediaSession(
-    val id: String,
-    val trackerSessionId: String?,
-    val state: MediaState,
-    val dispatchHandler: (event: Event) -> Unit
+    protected val id: String,
+    protected var trackerSessionId: String?,
+    protected val state: MediaState,
+    protected val dispatchHandler: (event: Event) -> Unit
 ) {
 
     companion object {
@@ -34,8 +34,8 @@ internal abstract class MediaSession(
         private val SOURCE_TAG = "MediaSession"
     }
 
-    var isSessionActive: Boolean = true
-    var sessionEndHandler: () -> Unit = {}
+    protected var isSessionActive: Boolean = true
+    protected var sessionEndHandler: () -> Unit = {}
 
     /**
      * Queues the [XDMMediaEvent].

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -91,18 +91,18 @@ internal abstract class MediaSession(
     /**
      * Ends the current session.
      */
-    abstract fun handleSessionEnd()
+    protected abstract fun handleSessionEnd()
 
     /**
      * Aborts the current session.
      */
-    abstract fun handleSessionAbort()
+    protected abstract fun handleSessionAbort()
 
     /**
      * Queues the [XDMMediaEvent] for processing.
      * @param event [XDMMediaEvent] to be queued
      */
-    abstract fun handleQueueEvent(event: XDMMediaEvent)
+    protected abstract fun handleQueueEvent(event: XDMMediaEvent)
 
     /**
      * Handles response from server containing the session ID.

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.media.internal
 
+import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
 import com.adobe.marketing.mobile.services.Log
@@ -18,7 +19,6 @@ import com.adobe.marketing.mobile.services.Log
 /**
  * A Media Session
  * @property id unique identifier for this Media Session
- * @property trackerSessionId unique identifier for the tracker session used for debugging
  * @property state [MediaState] holding state data
  * @property dispatchHandler closure for dispatching [Event]s
  */
@@ -33,8 +33,11 @@ internal abstract class MediaSession(
         private const val SOURCE_TAG = "MediaSession"
     }
 
-    protected var isSessionActive: Boolean = true
-    protected var sessionEndHandler: () -> Unit = {}
+    @VisibleForTesting
+    internal var isSessionActive: Boolean = true
+
+    @VisibleForTesting
+    internal var sessionEndHandler: () -> Unit = {}
 
     /**
      * Queues the [XDMMediaEvent].

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.media.internal
 
 import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.edge.media.internal.MediaInternalConstants.LOG_TAG
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
 import com.adobe.marketing.mobile.services.Log
 
@@ -28,10 +29,7 @@ internal abstract class MediaSession(
     protected val dispatchHandler: (event: Event) -> Unit
 ) {
 
-    companion object {
-        private const val LOG_TAG = MediaInternalConstants.LOG_TAG
-        private const val SOURCE_TAG = "MediaSession"
-    }
+    private val sourceTag = "MediaSession" // Log source tag
 
     @VisibleForTesting
     internal var isSessionActive: Boolean = true
@@ -47,7 +45,7 @@ internal abstract class MediaSession(
      */
     fun queue(event: XDMMediaEvent) {
         if (!isSessionActive) {
-            Log.debug(LOG_TAG, SOURCE_TAG, "queue - failed to queue event. Media Session ($id) is inactive.")
+            Log.debug(LOG_TAG, sourceTag, "queue - failed to queue event. Media Session ($id) is inactive.")
             return
         }
         handleQueueEvent(event)
@@ -59,7 +57,7 @@ internal abstract class MediaSession(
      */
     fun end(sessionEndHandler: () -> Unit = {}) {
         if (!isSessionActive) {
-            Log.debug(LOG_TAG, SOURCE_TAG, "end - failed to end session. Media Session ($id) is inactive.")
+            Log.debug(LOG_TAG, sourceTag, "end - failed to end session. Media Session ($id) is inactive.")
             return
         }
 
@@ -74,7 +72,7 @@ internal abstract class MediaSession(
      */
     fun abort(sessionEndHandler: () -> Unit = {}) {
         if (!isSessionActive) {
-            Log.debug(LOG_TAG, SOURCE_TAG, "abort - failed to abort session. Media Session ($id) is inactive.")
+            Log.debug(LOG_TAG, sourceTag, "abort - failed to abort session. Media Session ($id) is inactive.")
             return
         }
 

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -24,14 +24,13 @@ import com.adobe.marketing.mobile.services.Log
  */
 internal abstract class MediaSession(
     protected val id: String,
-    protected var trackerSessionId: String?,
     protected val state: MediaState,
     protected val dispatchHandler: (event: Event) -> Unit
 ) {
 
     companion object {
-        private val LOG_TAG = MediaInternalConstants.LOG_TAG
-        private val SOURCE_TAG = "MediaSession"
+        private const val LOG_TAG = MediaInternalConstants.LOG_TAG
+        private const val SOURCE_TAG = "MediaSession"
     }
 
     protected var isSessionActive: Boolean = true

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaSession.kt
@@ -1,0 +1,118 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.services.Log
+
+/**
+ * A Media Session
+ * @property id unique identifier for this Media Session
+ * @property trackerSessionId unique identifier for the tracker session used for debugging
+ * @property state [MediaState] holding state data
+ * @property dispatchHandler closure for dispatching [Event]s
+ */
+internal abstract class MediaSession(
+    val id: String,
+    val trackerSessionId: String?,
+    val state: MediaState,
+    val dispatchHandler: (event: Event) -> Unit
+) {
+
+    companion object {
+        private val LOG_TAG = MediaInternalConstants.LOG_TAG
+        private val SOURCE_TAG = "MediaSession"
+    }
+
+    var isSessionActive: Boolean = true
+    var sessionEndHandler: () -> Unit = {}
+
+    /**
+     * Queues the [XDMMediaEvent].
+     * Operation fails if the current session was ended or aborted.
+     *
+     * @param event the [XDMMediaEvent] to queue
+     */
+    fun queue(event: XDMMediaEvent) {
+        if (!isSessionActive) {
+            Log.debug(LOG_TAG, SOURCE_TAG, "queue - failed to queue event. Media Session ($id) is inactive.")
+            return
+        }
+        handleQueueEvent(event)
+    }
+
+    /**
+     * Ends the current session.
+     * @param sessionEndHandler closure called after session is successfully ended
+     */
+    fun end(sessionEndHandler: () -> Unit = {}) {
+        if (!isSessionActive) {
+            Log.debug(LOG_TAG, SOURCE_TAG, "end - failed to end session. Media Session ($id) is inactive.")
+            return
+        }
+
+        this.sessionEndHandler = sessionEndHandler
+        isSessionActive = false
+        handleSessionEnd()
+    }
+
+    /**
+     * Aborts the current session.
+     * @param sessionEndHandler closure called after session is successfully aborted
+     */
+    fun abort(sessionEndHandler: () -> Unit = {}) {
+        if (!isSessionActive) {
+            Log.debug(LOG_TAG, SOURCE_TAG, "abort - failed to abort session. Media Session ($id) is inactive.")
+            return
+        }
+
+        this.sessionEndHandler = sessionEndHandler
+        isSessionActive = false
+        handleSessionAbort()
+    }
+
+    /**
+     * Called when [MediaState] for this session is updated.
+     */
+    abstract fun handleMediaStateUpdate()
+
+    /**
+     * Ends the current session.
+     */
+    abstract fun handleSessionEnd()
+
+    /**
+     * Aborts the current session.
+     */
+    abstract fun handleSessionAbort()
+
+    /**
+     * Queues the [XDMMediaEvent] for processing.
+     * @param event [XDMMediaEvent] to be queued
+     */
+    abstract fun handleQueueEvent(event: XDMMediaEvent)
+
+    /**
+     * Handles response from server containing the session ID.
+     * @param requestEventId the [Edge] request event ID
+     * @param backendSessionId the backend session ID for the current [MediaSession]
+     */
+    abstract fun handleSessionUpdate(requestEventId: String, backendSessionId: String?)
+
+    /**
+     * Handles error responses from the server.
+     * @param requestEventId the [Edge] request event ID
+     * @param data contains errors returned by the backend server
+     */
+    abstract fun handleErrorResponse(requestEventId: String, data: Map<String, Any>)
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
@@ -1,0 +1,31 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+internal data class XDMMediaEvent(
+    var xdmData: XDMMediaSchema? = null,
+    var path: String? = null
+) : XDMProperty {
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        xdmData?.let {
+            map.put("xdm", it)
+        }
+
+        path?.let {
+            map.put("request", mapOf("path" to it))
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
@@ -12,18 +12,16 @@
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
 internal data class XDMMediaEvent(
-    var xdmData: XDMMediaSchema? = null
+    var xdmData: XDMMediaSchema
 ) : XDMProperty {
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()
 
-        xdmData?.let {
-            map["xdm"] = it.serializeToXDM()
+        map["xdm"] = xdmData.serializeToXDM()
 
-            // Set Media overwrite path based on XDM eventType
-            it.eventType?.let { eventType ->
-                map.put("request", mapOf("path" to "/va/v1/${eventType.value}"))
-            }
+        // Set Media overwrite path based on XDM eventType
+        xdmData.eventType?.let { eventType ->
+            map.put("request", mapOf("path" to "/va/v1/${eventType.value}"))
         }
 
         return map.toMap()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
@@ -12,18 +12,18 @@
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
 internal data class XDMMediaEvent(
-    var xdmData: XDMMediaSchema? = null,
-    var path: String? = null
+    var xdmData: XDMMediaSchema? = null
 ) : XDMProperty {
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()
 
         xdmData?.let {
-            map.put("xdm", it)
-        }
+            map["xdm"] = it
 
-        path?.let {
-            map.put("request", mapOf("path" to it))
+            // Set Media overwrite path based on XDM eventType
+            it.eventType?.let { eventType ->
+                map.put("request", mapOf("path" to "/va/v1/${eventType.value}"))
+            }
         }
 
         return map.toMap()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
@@ -18,7 +18,7 @@ internal data class XDMMediaEvent(
         val map = mutableMapOf<String, Any>()
 
         xdmData?.let {
-            map["xdm"] = it
+            map["xdm"] = it.serializeToXDM()
 
             // Set Media overwrite path based on XDM eventType
             it.eventType?.let { eventType ->

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEvent.kt
@@ -20,9 +20,7 @@ internal data class XDMMediaEvent(
         map["xdm"] = xdmData.serializeToXDM()
 
         // Set Media overwrite path based on XDM eventType
-        xdmData.eventType?.let { eventType ->
-            map.put("request", mapOf("path" to "/va/v1/${eventType.value}"))
-        }
+        map["request"] = mapOf("path" to "/va/v1/${xdmData.eventType.value}")
 
         return map.toMap()
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaEventType.kt
@@ -12,22 +12,28 @@
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
 internal enum class XDMMediaEventType(val value: String) {
-    SESSION_START("media.sessionStart"),
-    SESSION_COMPLETE("media.sessionComplete"),
-    SESSION_END("media.sessionEnd"),
-    PLAY("media.play"),
-    PAUSE_START("media.pauseStart"),
-    PING("media.ping"),
-    ERROR("media.error"),
-    BUFFER_START("media.bufferStart"),
-    BITRATE_CHANGE("media.bitrateChange"),
-    AD_BREAK_START("media.adBreakStart"),
-    AD_BREAK_COMPLETE("media.adBreakComplete"),
-    AD_START("media.adStart"),
-    AD_SKIP("media.adSkip"),
-    AD_COMPLETE("media.adComplete"),
-    CHAPTER_SKIP("media.chapterSkip"),
-    CHAPTER_START("media.chapterStart"),
-    CHAPTER_COMPLETE("media.chapterComplete"),
-    STATES_UPDATE("media.statesUpdate")
+    SESSION_START("sessionStart"),
+    SESSION_COMPLETE("sessionComplete"),
+    SESSION_END("sessionEnd"),
+    PLAY("play"),
+    PAUSE_START("pauseStart"),
+    PING("ping"),
+    ERROR("error"),
+    BUFFER_START("bufferStart"),
+    BITRATE_CHANGE("bitrateChange"),
+    AD_BREAK_START("adBreakStart"),
+    AD_BREAK_COMPLETE("adBreakComplete"),
+    AD_START("adStart"),
+    AD_SKIP("adSkip"),
+    AD_COMPLETE("adComplete"),
+    CHAPTER_SKIP("chapterSkip"),
+    CHAPTER_START("chapterStart"),
+    CHAPTER_COMPLETE("chapterComplete"),
+    STATES_UPDATE("statesUpdate");
+
+    companion object {
+        fun getTypeString(type: XDMMediaEventType): String {
+            return "media.${type.value}"
+        }
+    }
 }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
@@ -1,0 +1,40 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal.xdm
+
+import com.adobe.marketing.mobile.util.TimeUtils
+import java.util.Date
+
+internal data class XDMMediaSchema(
+    var timestamp: Date? = null,
+    var eventType: XDMMediaEventType? = null,
+    var mediaCollection: XDMMediaCollection? = null
+) : XDMProperty {
+
+    override fun serializeToXDM(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+
+        eventType?.let {
+            map.put("eventType", it.value)
+        }
+
+        timestamp?.let {
+            map.put("timestamp", TimeUtils.getISO8601UTCDateWithMilliseconds(it))
+        }
+
+        mediaCollection?.let {
+            map.put("mediaCollection", it)
+        }
+
+        return map.toMap()
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
@@ -32,7 +32,7 @@ internal data class XDMMediaSchema(
         }
 
         mediaCollection?.let {
-            map.put("mediaCollection", it)
+            map.put("mediaCollection", it.serializeToXDM())
         }
 
         return map.toMap()

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
@@ -15,17 +15,15 @@ import com.adobe.marketing.mobile.util.TimeUtils
 import java.util.Date
 
 internal data class XDMMediaSchema(
+    var eventType: XDMMediaEventType,
     var timestamp: Date? = null,
-    var eventType: XDMMediaEventType? = null,
     var mediaCollection: XDMMediaCollection? = null
 ) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
         val map = mutableMapOf<String, Any>()
 
-        eventType?.let {
-            map.put("eventType", XDMMediaEventType.getTypeString(it))
-        }
+        map["eventType"] = XDMMediaEventType.getTypeString(eventType)
 
         timestamp?.let {
             map.put("timestamp", TimeUtils.getISO8601UTCDateWithMilliseconds(it))

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
@@ -16,8 +16,8 @@ import java.util.Date
 
 internal data class XDMMediaSchema(
     var eventType: XDMMediaEventType,
-    var timestamp: Date? = null,
-    var mediaCollection: XDMMediaCollection? = null
+    var timestamp: Date,
+    var mediaCollection: XDMMediaCollection
 ) : XDMProperty {
 
     override fun serializeToXDM(): Map<String, Any> {
@@ -25,13 +25,9 @@ internal data class XDMMediaSchema(
 
         map["eventType"] = XDMMediaEventType.getTypeString(eventType)
 
-        timestamp?.let {
-            map.put("timestamp", TimeUtils.getISO8601UTCDateWithMilliseconds(it))
-        }
+        map["timestamp"] = TimeUtils.getISO8601UTCDateWithMilliseconds(timestamp)
 
-        mediaCollection?.let {
-            map.put("mediaCollection", it.serializeToXDM())
-        }
+        map["mediaCollection"] = mediaCollection.serializeToXDM()
 
         return map.toMap()
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMMediaSchema.kt
@@ -24,7 +24,7 @@ internal data class XDMMediaSchema(
         val map = mutableMapOf<String, Any>()
 
         eventType?.let {
-            map.put("eventType", it.value)
+            map.put("eventType", XDMMediaEventType.getTypeString(it))
         }
 
         timestamp?.let {

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/MediaTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/MediaTests.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 public class MediaTests {
 
     static final String EVENT_TYPE_MEDIA = "com.adobe.eventType.edgeMedia";
-    static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.requestTracker";
+    static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.createTracker";
     static final String TRACKER_ID = "trackerid";
     static final String TRACKER_EVENT_PARAM = "event.param";
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -606,8 +606,7 @@ class MediaRealTimeSessionTests {
     }
 
     private fun getXDMMediaEvent(forType: XDMMediaEventType): XDMMediaEvent {
-        val schema = XDMMediaSchema()
-        schema.eventType = forType
+        val schema = XDMMediaSchema(forType)
         schema.timestamp = Date()
         schema.mediaCollection = XDMMediaCollection()
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -1,0 +1,632 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMAdvertisingDetails
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaCollection
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMSessionDetails
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class MediaRealTimeSessionTests {
+    private val id = "testSessionId"
+    private var mockState: MediaState = Mockito.mock(MediaState::class.java)
+    private val dispatcher: (Event) -> Unit = { }
+
+    @Test
+    fun `mediaBackendSessionId set with non-null non-empty value updates id`() {
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.mediaBackendSessionId = "validId"
+        assertEquals("validId", session.mediaBackendSessionId)
+    }
+
+    @Test
+    fun `mediaBackendSessionId set with null value does not update id`() {
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.mediaBackendSessionId = null
+        assertNull(session.mediaBackendSessionId)
+    }
+
+    @Test
+    fun `mediaBackendSessionId set with empty value does not update id`() {
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.mediaBackendSessionId = ""
+        assertNull(session.mediaBackendSessionId)
+    }
+
+    @Test
+    fun `handleSessionUpdate() sets backend session id and processes media events`() {
+        val requestEventId = "edgeRequestId"
+        val sessionId = "backendSessionId"
+
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.sessionStartEdgeRequestId = requestEventId // current request ID must match passed ID
+        session.events.add(event)
+
+        session.handleSessionUpdate(requestEventId, sessionId)
+
+        assertEquals(sessionId, session.mediaBackendSessionId)
+        assertTrue(session.isSessionActive) // verify session is still active
+        assertTrue(session.events.isEmpty())
+    }
+
+    @Test
+    fun `handleSessionUpdate() sets backend session id while aborts if backend session id is null`() {
+        val requestEventId = "edgeRequestId"
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.sessionStartEdgeRequestId = requestEventId // current request ID must match passed ID
+        session.events.add(XDMMediaEvent())
+        session.mediaBackendSessionId = "sessionId" // set valid backend session ID
+
+        session.handleSessionUpdate(requestEventId, "") // pass invalid session ID
+
+        assertNull(session.mediaBackendSessionId)
+        assertFalse(session.isSessionActive) // verify session is inactive from abort() call
+        assertTrue(session.events.isEmpty()) // event queue is cleared from abort() call
+    }
+
+    @Test
+    fun `handleSessionUpdate() performs no operation if edge request id does not match`() {
+        val requestEventId = "edgeRequestId"
+        val sessionId = "backendSessionId"
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.sessionStartEdgeRequestId = "otherEdgeRequestID"
+        session.events.add(XDMMediaEvent())
+        session.mediaBackendSessionId = sessionId // set valid backend session ID
+
+        session.handleSessionUpdate(requestEventId, "otherSessionId")
+
+        assertEquals(sessionId, session.mediaBackendSessionId) // verify backend session id unchanged
+        assertTrue(session.isSessionActive) // verify session is still active
+        assertFalse(session.events.isEmpty()) // event queue not processed
+    }
+
+    @Test
+    fun `handleErrorResponse() with VA Edge 400 error aborts session`() {
+        val requestId = "edgeRequestId"
+        val data = mapOf<String, Any>("status" to 400L, "type" to "https://ns.adobe.com/aep/errors/va-edge-0400-400")
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        val latch = CountDownLatch(1)
+        session.sessionEndHandler = { latch.countDown() }
+
+        session.handleErrorResponse(requestId, data)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertTrue(session.events.isEmpty())
+        assertFalse(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleErrorResponse() with VA Edge 400 error and extra fields aborts session`() {
+        val requestId = "edgeRequestId"
+        val data = mapOf(
+            "status" to 400L,
+            "type" to "https://ns.adobe.com/aep/errors/va-edge-0400-400",
+            "title" to "Not Found",
+            "detail" to "The requested resource could not be found by may be available again in the future.",
+            "report" to mapOf("details" to "Error processing request.")
+        )
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        val latch = CountDownLatch(1)
+        session.sessionEndHandler = { latch.countDown() }
+
+        session.handleErrorResponse(requestId, data)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertTrue(session.events.isEmpty())
+        assertFalse(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleErrorResponse() with error code not 400 does not abort session`() {
+        val requestId = "edgeRequestId"
+        val data = mapOf<String, Any>("status" to 200L, "type" to "https://ns.adobe.com/aep/errors/va-edge-0400-400")
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        session.sessionEndHandler = { fail("Session end handler should not be called!") }
+
+        session.handleErrorResponse(requestId, data)
+
+        // Add delay to ensure session end handler is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+
+        assertFalse(session.events.isEmpty())
+        assertTrue(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleErrorResponse() with error type not VA Edge 400 does not abort session`() {
+        val requestId = "edgeRequestId"
+        val data = mapOf<String, Any>("status" to 400L, "type" to "https://ns.adobe.com/aep/errors/va-edge-0200-200")
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        session.sessionEndHandler = { fail("Session end handler should not be called!") }
+
+        session.handleErrorResponse(requestId, data)
+
+        // Add delay to ensure session end handler is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+
+        assertFalse(session.events.isEmpty())
+        assertTrue(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleErrorResponse() with incorrect error data does not abort session`() {
+        val requestId = "edgeRequestId"
+        // Data should contain "type" and "status" fields
+        val data = mapOf<String, Any>("hello" to 400L, "world" to "https://ns.adobe.com/aep/errors/va-edge-0200-200")
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        session.sessionEndHandler = { fail("Session end handler should not be called!") }
+
+        session.handleErrorResponse(requestId, data)
+
+        // Add delay to ensure session end handler is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+
+        assertFalse(session.events.isEmpty())
+        assertTrue(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleErrorResponse() when passed wrong request event ID does not abort session`() {
+        val requestId = "edgeRequestId"
+        val data = mapOf<String, Any>("status" to 400L, "type" to "https://ns.adobe.com/aep/errors/va-edge-0400-400")
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+        session.sessionStartEdgeRequestId = requestId // current request id must match to process request
+
+        session.sessionEndHandler = { fail("Session end handler should not be called!") }
+
+        session.handleErrorResponse("otherRequestId", data)
+
+        // Add delay to ensure session end handler is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+
+        assertFalse(session.events.isEmpty())
+        assertTrue(session.isSessionActive)
+    }
+
+    @Test
+    fun `handleMediaStateUpdate() processes event queue`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(event)
+
+        // Verify events queue is empty after calling handleMediaStateUpdate
+        session.handleMediaStateUpdate()
+        assertTrue(session.events.isEmpty())
+    }
+
+    @Test
+    fun `end() processes event queue and calls session end handler when queue is empty`() {
+        `when`(mockState.isValid).thenReturn(true)
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(event)
+
+        val latch = CountDownLatch(1)
+
+        session.end { latch.countDown() }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertTrue(session.events.isEmpty())
+    }
+
+    @Test
+    fun `end() processes event queue but does not call session end handler when queue is not empty`() {
+        `when`(mockState.isValid).thenReturn(false) // stop event processing
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(event)
+
+        session.end { fail("Session end handler should not be called!") }
+
+        // Add delay to ensure session end handler is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+        assertFalse(session.events.isEmpty())
+    }
+
+    @Test
+    fun `abort() clears queue and calls session end handler`() {
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
+
+        val latch = CountDownLatch(1)
+
+        session.abort { latch.countDown() }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertTrue(session.events.isEmpty())
+    }
+
+    @Test
+    fun `queue() adds event to queue`() {
+        // Set invalid MediaState to prevent processing event queue
+        `when`(mockState.isValid).thenReturn(false)
+        // Set event type to media.sessionStart to allow event processing
+        val event1 = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+        val event2 = getXDMMediaEvent(XDMMediaEventType.SESSION_END)
+
+        val session = MediaRealTimeSession(id, mockState, dispatcher)
+
+        session.queue(event1)
+        session.queue(event2)
+
+        // MediaState was set to invalid so event will still be in queue
+        assertEquals(2, session.events.size)
+        assertEquals(event1, session.events[0])
+        assertEquals(event2, session.events[1])
+    }
+
+    @Test
+    fun `queue() processes event and dispatches experience event`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val latch = CountDownLatch(1)
+
+        var dispatchedEvent: Event? = null
+        val session = MediaRealTimeSession(id, mockState) {
+            dispatchedEvent = it
+            latch.countDown()
+        }
+
+        session.queue(event)
+
+        assertTrue("Timeout waiting for dispatcher.", latch.await(2, TimeUnit.SECONDS))
+        assertNotNull(dispatchedEvent)
+
+        dispatchedEvent?.let { dispatched ->
+            assertEquals("Edge Media media.sessionStart", dispatched.name)
+            assertEquals(EventType.EDGE, dispatched.type)
+            assertEquals(EventSource.REQUEST_CONTENT, dispatched.source)
+            assertNotNull(dispatched.eventData)
+        }
+    }
+
+    @Test
+    fun `queue() does not process non-sessionStart events if backend session id is null`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.PLAY)
+
+        val session = MediaRealTimeSession(id, mockState) {
+            fail("Session end handler should not be called!")
+        }
+
+        session.mediaBackendSessionId = null
+
+        session.queue(event)
+
+        // Add delay to ensure dispatcher is not called
+        runBlocking {
+            delay(TimeUnit.SECONDS.toMillis(1))
+        }
+        assertFalse(session.events.isEmpty())
+    }
+
+    @Test
+    fun `queue() processes session start event and attaches media state info`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+        `when`(mockState.mediaPlayerName).thenReturn("testPlayer")
+        `when`(mockState.mediaChannel).thenReturn("testChannel")
+        `when`(mockState.mediaAppVersion).thenReturn("testVersion")
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+
+        val latch = CountDownLatch(1)
+
+        var dispatchedEvent: Event? = null
+        val session = MediaRealTimeSession(id, mockState) {
+            dispatchedEvent = it
+            latch.countDown()
+        }
+
+        session.queue(event)
+
+        assertTrue("Timeout waiting for dispatcher.", latch.await(2, TimeUnit.SECONDS))
+        assertNotNull(dispatchedEvent)
+
+        dispatchedEvent?.let { dispatched ->
+            val flatMap = flatten(dispatched.eventData)
+            assertEquals("testPlayer", flatMap["xdm.mediaCollection.sessionDetails.playerName"])
+            assertEquals("testChannel", flatMap["xdm.mediaCollection.sessionDetails.channel"])
+            assertEquals("testVersion", flatMap["xdm.mediaCollection.sessionDetails.appVersion"])
+        }
+    }
+
+    @Test
+    fun `queue() processes session start event but does not overwrite session channel value`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+        `when`(mockState.mediaPlayerName).thenReturn("testPlayer")
+        `when`(mockState.mediaChannel).thenReturn("testChannel")
+        `when`(mockState.mediaAppVersion).thenReturn("testVersion")
+
+        // Set event type to media.sessionStart to allow event processing
+        val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
+        event.xdmData?.mediaCollection?.sessionDetails?.channel = "myChannel"
+
+        val latch = CountDownLatch(1)
+
+        var dispatchedEvent: Event? = null
+        val session = MediaRealTimeSession(id, mockState) {
+            dispatchedEvent = it
+            latch.countDown()
+        }
+
+        session.queue(event)
+
+        assertTrue("Timeout waiting for dispatcher.", latch.await(2, TimeUnit.SECONDS))
+        assertNotNull(dispatchedEvent)
+
+        dispatchedEvent?.let { dispatched ->
+            val flatMap = flatten(dispatched.eventData)
+            assertEquals("testPlayer", flatMap["xdm.mediaCollection.sessionDetails.playerName"])
+            assertEquals("myChannel", flatMap["xdm.mediaCollection.sessionDetails.channel"]) // channel is same from event
+            assertEquals("testVersion", flatMap["xdm.mediaCollection.sessionDetails.appVersion"])
+        }
+    }
+
+    @Test
+    fun `queue() processes ad start event and attaches media state info and session id`() {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+        `when`(mockState.mediaPlayerName).thenReturn("testPlayer")
+
+        val event = getXDMMediaEvent(XDMMediaEventType.AD_START)
+
+        val latch = CountDownLatch(1)
+
+        var dispatchedEvent: Event? = null
+        val session = MediaRealTimeSession(id, mockState) {
+            dispatchedEvent = it
+            latch.countDown()
+        }
+        session.mediaBackendSessionId = "sessionId"
+
+        session.queue(event)
+
+        assertTrue("Timeout waiting for dispatcher.", latch.await(2, TimeUnit.SECONDS))
+        assertNotNull(dispatchedEvent)
+
+        dispatchedEvent?.let { dispatched ->
+            val flatMap = flatten(dispatched.eventData)
+            assertEquals("testPlayer", flatMap["xdm.mediaCollection.advertisingDetails.playerName"])
+            assertEquals("sessionId", flatMap["xdm.mediaCollection.sessionID"])
+        }
+    }
+
+    @Test
+    fun `queue() processes session complete event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.SESSION_COMPLETE, "/va/1/sessionComplete")
+    }
+
+    @Test
+    fun `queue() processes session end event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.SESSION_END, "/va/1/sessionEnd")
+    }
+
+    @Test
+    fun `queue() processes play event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.PLAY, "/va/1/play")
+    }
+
+    @Test
+    fun `queue() processes pause start event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.PAUSE_START, "/va/1/pauseStart")
+    }
+
+    @Test
+    fun `queue() processes ping event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.PING, "/va/1/ping")
+    }
+
+    @Test
+    fun `queue() processes error event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.ERROR, "/va/1/error")
+    }
+
+    @Test
+    fun `queue() processes buffer start event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.BUFFER_START, "/va/1/bufferStart")
+    }
+
+    @Test
+    fun `queue() processes bitrate change event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.BITRATE_CHANGE, "/va/1/bitrateChange")
+    }
+
+    @Test
+    fun `queue() processes ad break start event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_START, "/va/1/adBreakSkip")
+    }
+
+    @Test
+    fun `queue() processes ad break complete event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_COMPLETE, "/va/1/adBreakComplete")
+    }
+
+    @Test
+    fun `queue() processes ad skip event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.AD_SKIP, "/va/1/adSkip")
+    }
+
+    @Test
+    fun `queue() processes ad complete event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.AD_COMPLETE, "/va/1/adComplete")
+    }
+
+    @Test
+    fun `queue() processes chapter skip event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_SKIP, "/va/1/chapterSkip")
+    }
+
+    @Test
+    fun `queue() processes chapter start event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_START, "/va/1/chapterStart")
+    }
+
+    @Test
+    fun `queue() processes chapter complete event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_COMPLETE, "/va/1/chapterComplete")
+    }
+
+    @Test
+    fun `queue() processes states update event and attaches session id`() {
+        assertQueueAddsSessionId(XDMMediaEventType.STATES_UPDATE, "/va/1/statesUpdate")
+    }
+
+    private fun assertQueueAddsSessionId(forType: XDMMediaEventType, overwritePath: String) {
+        // MediaState needs to be valid to process event queue
+        `when`(mockState.isValid).thenReturn(true)
+
+        val event = getXDMMediaEvent(forType)
+
+        val latch = CountDownLatch(1)
+
+        var dispatchedEvent: Event? = null
+        val session = MediaRealTimeSession(id, mockState) {
+            dispatchedEvent = it
+            latch.countDown()
+        }
+        session.mediaBackendSessionId = "sessionId"
+
+        session.queue(event)
+
+        assertTrue("[${forType.value}] Timeout waiting for dispatcher.", latch.await(2, TimeUnit.SECONDS))
+        assertNotNull("[${forType.value}] Did not dispatch event!", dispatchedEvent)
+
+        dispatchedEvent?.let { dispatched ->
+            val flatMap = flatten(dispatched.eventData)
+            assertEquals(
+                "[${forType.value}] backend session ID does not match.",
+                "sessionId",
+                flatMap["xdm.mediaCollection.sessionID"]
+            )
+            // TODO assert path overwrite
+        }
+    }
+
+    private fun getXDMMediaEvent(forType: XDMMediaEventType): XDMMediaEvent {
+        val schema = XDMMediaSchema()
+        schema.eventType = forType
+        schema.timestamp = Date()
+        schema.mediaCollection = XDMMediaCollection()
+
+        when (forType) {
+            XDMMediaEventType.SESSION_START -> {
+                val sessionDetails = XDMSessionDetails()
+                sessionDetails.playerName = "myPlayer"
+                sessionDetails.name = "mySession"
+                schema.mediaCollection?.sessionDetails = sessionDetails
+            }
+            XDMMediaEventType.AD_START -> {
+                val advertisingDetails = XDMAdvertisingDetails()
+                schema.mediaCollection?.advertisingDetails = advertisingDetails
+            }
+            else -> {
+                // nothing more needed
+            }
+        }
+
+        val event = XDMMediaEvent()
+        event.xdmData = schema
+        return event
+    }
+
+    private fun flatten(map: Map<String, Any>, prefix: String = ""): Map<String, Any> {
+        val keyPrefix = if (prefix.isEmpty()) prefix else "$prefix."
+        val flattened = mutableMapOf<String, Any>()
+        map.forEach { (key, value) ->
+            val expandedKey = "$keyPrefix$key"
+            if (value is Map<*, *>) {
+                flattened += flatten(value as Map<String, Any>, expandedKey)
+            } else {
+                flattened[expandedKey] = value
+            }
+        }
+        return flattened
+    }
+}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -126,9 +126,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         val latch = CountDownLatch(1)
-        session.sessionEndHandler = { latch.countDown() }
 
-        session.handleErrorResponse(requestId, data)
+        session.handleErrorResponse(requestId, data) {
+            latch.countDown()
+        }
 
         assertTrue(latch.await(2, TimeUnit.SECONDS))
         assertTrue(session.events.isEmpty())
@@ -151,9 +152,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         val latch = CountDownLatch(1)
-        session.sessionEndHandler = { latch.countDown() }
 
-        session.handleErrorResponse(requestId, data)
+        session.handleErrorResponse(requestId, data) {
+            latch.countDown()
+        }
 
         assertTrue(latch.await(2, TimeUnit.SECONDS))
         assertTrue(session.events.isEmpty())
@@ -169,9 +171,9 @@ class MediaRealTimeSessionTests {
         session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
-        session.sessionEndHandler = { fail("Session end handler should not be called!") }
-
-        session.handleErrorResponse(requestId, data)
+        session.handleErrorResponse(requestId, data) {
+            fail("Session end handler should not be called!")
+        }
 
         // Add delay to ensure session end handler is not called
         runBlocking {
@@ -191,9 +193,9 @@ class MediaRealTimeSessionTests {
         session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
-        session.sessionEndHandler = { fail("Session end handler should not be called!") }
-
-        session.handleErrorResponse(requestId, data)
+        session.handleErrorResponse(requestId, data) {
+            fail("Session end handler should not be called!")
+        }
 
         // Add delay to ensure session end handler is not called
         runBlocking {
@@ -214,9 +216,9 @@ class MediaRealTimeSessionTests {
         session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
-        session.sessionEndHandler = { fail("Session end handler should not be called!") }
-
-        session.handleErrorResponse(requestId, data)
+        session.handleErrorResponse(requestId, data) {
+            fail("Session end handler should not be called!")
+        }
 
         // Add delay to ensure session end handler is not called
         runBlocking {
@@ -236,9 +238,9 @@ class MediaRealTimeSessionTests {
         session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
-        session.sessionEndHandler = { fail("Session end handler should not be called!") }
-
-        session.handleErrorResponse("otherRequestId", data)
+        session.handleErrorResponse("otherRequestId", data) {
+            fail("Session end handler should not be called!")
+        }
 
         // Add delay to ensure session end handler is not called
         runBlocking {

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -89,7 +89,7 @@ class MediaRealTimeSessionTests {
 
         val session = MediaRealTimeSession(id, mockState, dispatcher)
         session.sessionStartEdgeRequestId = requestEventId // current request ID must match passed ID
-        session.events.add(XDMMediaEvent())
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.PLAY))
         session.mediaBackendSessionId = "sessionId" // set valid backend session ID
 
         session.handleSessionUpdate(requestEventId, "") // pass invalid session ID
@@ -106,7 +106,7 @@ class MediaRealTimeSessionTests {
 
         val session = MediaRealTimeSession(id, mockState, dispatcher)
         session.sessionStartEdgeRequestId = "otherEdgeRequestID"
-        session.events.add(XDMMediaEvent())
+        session.events.add(getXDMMediaEvent(XDMMediaEventType.PLAY))
         session.mediaBackendSessionId = sessionId // set valid backend session ID
 
         session.handleSessionUpdate(requestEventId, "otherSessionId")
@@ -627,9 +627,7 @@ class MediaRealTimeSessionTests {
             }
         }
 
-        val event = XDMMediaEvent()
-        event.xdmData = schema
-        return event
+        return XDMMediaEvent(schema)
     }
 
     private fun flatten(map: Map<String, Any>, prefix: String = ""): Map<String, Any> {

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -427,7 +427,7 @@ class MediaRealTimeSessionTests {
 
         // Set event type to media.sessionStart to allow event processing
         val event = getXDMMediaEvent(XDMMediaEventType.SESSION_START)
-        event.xdmData?.mediaCollection?.sessionDetails?.channel = "myChannel"
+        event.xdmData.mediaCollection.sessionDetails?.channel = "myChannel"
 
         val latch = CountDownLatch(1)
 
@@ -606,20 +606,17 @@ class MediaRealTimeSessionTests {
     }
 
     private fun getXDMMediaEvent(forType: XDMMediaEventType): XDMMediaEvent {
-        val schema = XDMMediaSchema(forType)
-        schema.timestamp = Date()
-        schema.mediaCollection = XDMMediaCollection()
-
+        val schema = XDMMediaSchema(forType, Date(), XDMMediaCollection())
         when (forType) {
             XDMMediaEventType.SESSION_START -> {
                 val sessionDetails = XDMSessionDetails()
                 sessionDetails.playerName = "myPlayer"
                 sessionDetails.name = "mySession"
-                schema.mediaCollection?.sessionDetails = sessionDetails
+                schema.mediaCollection.sessionDetails = sessionDetails
             }
             XDMMediaEventType.AD_START -> {
                 val advertisingDetails = XDMAdvertisingDetails()
-                schema.mediaCollection?.advertisingDetails = advertisingDetails
+                schema.mediaCollection.advertisingDetails = advertisingDetails
             }
             else -> {
                 // nothing more needed

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -172,10 +172,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         session.handleErrorResponse(requestId, data) {
-            fail("Session end handler should not be called!")
+            fail("Session abort handler should not be called!")
         }
 
-        // Add delay to ensure session end handler is not called
+        // Add delay to ensure session abort handler is not called
         runBlocking {
             delay(TimeUnit.SECONDS.toMillis(1))
         }
@@ -194,10 +194,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         session.handleErrorResponse(requestId, data) {
-            fail("Session end handler should not be called!")
+            fail("Session abort handler should not be called!")
         }
 
-        // Add delay to ensure session end handler is not called
+        // Add delay to ensure session abort handler is not called
         runBlocking {
             delay(TimeUnit.SECONDS.toMillis(1))
         }
@@ -217,10 +217,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         session.handleErrorResponse(requestId, data) {
-            fail("Session end handler should not be called!")
+            fail("Session abort handler should not be called!")
         }
 
-        // Add delay to ensure session end handler is not called
+        // Add delay to ensure session abort handler is not called
         runBlocking {
             delay(TimeUnit.SECONDS.toMillis(1))
         }
@@ -239,10 +239,10 @@ class MediaRealTimeSessionTests {
         session.sessionStartEdgeRequestId = requestId // current request id must match to process request
 
         session.handleErrorResponse("otherRequestId", data) {
-            fail("Session end handler should not be called!")
+            fail("Session abort handler should not be called!")
         }
 
-        // Add delay to ensure session end handler is not called
+        // Add delay to ensure session abort handler is not called
         runBlocking {
             delay(TimeUnit.SECONDS.toMillis(1))
         }
@@ -303,7 +303,7 @@ class MediaRealTimeSessionTests {
     }
 
     @Test
-    fun `abort() clears queue and calls session end handler`() {
+    fun `abort() clears queue and calls session abort handler`() {
         val session = MediaRealTimeSession(id, mockState, dispatcher)
         session.events.add(getXDMMediaEvent(XDMMediaEventType.SESSION_START))
 
@@ -372,7 +372,7 @@ class MediaRealTimeSessionTests {
         val event = getXDMMediaEvent(XDMMediaEventType.PLAY)
 
         val session = MediaRealTimeSession(id, mockState) {
-            fail("Session end handler should not be called!")
+            fail("Dispatch handler should not be called!")
         }
 
         session.mediaBackendSessionId = null

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaRealTimeSessionTests.kt
@@ -354,7 +354,7 @@ class MediaRealTimeSessionTests {
         assertNotNull(dispatchedEvent)
 
         dispatchedEvent?.let { dispatched ->
-            assertEquals("Edge Media media.sessionStart", dispatched.name)
+            assertEquals("Edge Media - media.sessionStart", dispatched.name)
             assertEquals(EventType.EDGE, dispatched.type)
             assertEquals(EventSource.REQUEST_CONTENT, dispatched.source)
             assertNotNull(dispatched.eventData)
@@ -410,6 +410,7 @@ class MediaRealTimeSessionTests {
 
         dispatchedEvent?.let { dispatched ->
             val flatMap = flatten(dispatched.eventData)
+            assertEquals("media.sessionStart", flatMap["xdm.eventType"])
             assertEquals("testPlayer", flatMap["xdm.mediaCollection.sessionDetails.playerName"])
             assertEquals("testChannel", flatMap["xdm.mediaCollection.sessionDetails.channel"])
             assertEquals("testVersion", flatMap["xdm.mediaCollection.sessionDetails.appVersion"])
@@ -473,6 +474,7 @@ class MediaRealTimeSessionTests {
 
         dispatchedEvent?.let { dispatched ->
             val flatMap = flatten(dispatched.eventData)
+            assertEquals("media.adStart", flatMap["xdm.eventType"])
             assertEquals("testPlayer", flatMap["xdm.mediaCollection.advertisingDetails.playerName"])
             assertEquals("sessionId", flatMap["xdm.mediaCollection.sessionID"])
         }
@@ -480,85 +482,85 @@ class MediaRealTimeSessionTests {
 
     @Test
     fun `queue() processes session complete event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.SESSION_COMPLETE, "/va/1/sessionComplete")
+        assertQueueAddsSessionId(XDMMediaEventType.SESSION_COMPLETE)
     }
 
     @Test
     fun `queue() processes session end event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.SESSION_END, "/va/1/sessionEnd")
+        assertQueueAddsSessionId(XDMMediaEventType.SESSION_END)
     }
 
     @Test
     fun `queue() processes play event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.PLAY, "/va/1/play")
+        assertQueueAddsSessionId(XDMMediaEventType.PLAY)
     }
 
     @Test
     fun `queue() processes pause start event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.PAUSE_START, "/va/1/pauseStart")
+        assertQueueAddsSessionId(XDMMediaEventType.PAUSE_START)
     }
 
     @Test
     fun `queue() processes ping event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.PING, "/va/1/ping")
+        assertQueueAddsSessionId(XDMMediaEventType.PING)
     }
 
     @Test
     fun `queue() processes error event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.ERROR, "/va/1/error")
+        assertQueueAddsSessionId(XDMMediaEventType.ERROR)
     }
 
     @Test
     fun `queue() processes buffer start event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.BUFFER_START, "/va/1/bufferStart")
+        assertQueueAddsSessionId(XDMMediaEventType.BUFFER_START)
     }
 
     @Test
     fun `queue() processes bitrate change event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.BITRATE_CHANGE, "/va/1/bitrateChange")
+        assertQueueAddsSessionId(XDMMediaEventType.BITRATE_CHANGE)
     }
 
     @Test
     fun `queue() processes ad break start event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_START, "/va/1/adBreakSkip")
+        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_START)
     }
 
     @Test
     fun `queue() processes ad break complete event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_COMPLETE, "/va/1/adBreakComplete")
+        assertQueueAddsSessionId(XDMMediaEventType.AD_BREAK_COMPLETE)
     }
 
     @Test
     fun `queue() processes ad skip event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.AD_SKIP, "/va/1/adSkip")
+        assertQueueAddsSessionId(XDMMediaEventType.AD_SKIP)
     }
 
     @Test
     fun `queue() processes ad complete event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.AD_COMPLETE, "/va/1/adComplete")
+        assertQueueAddsSessionId(XDMMediaEventType.AD_COMPLETE)
     }
 
     @Test
     fun `queue() processes chapter skip event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_SKIP, "/va/1/chapterSkip")
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_SKIP)
     }
 
     @Test
     fun `queue() processes chapter start event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_START, "/va/1/chapterStart")
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_START)
     }
 
     @Test
     fun `queue() processes chapter complete event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_COMPLETE, "/va/1/chapterComplete")
+        assertQueueAddsSessionId(XDMMediaEventType.CHAPTER_COMPLETE)
     }
 
     @Test
     fun `queue() processes states update event and attaches session id`() {
-        assertQueueAddsSessionId(XDMMediaEventType.STATES_UPDATE, "/va/1/statesUpdate")
+        assertQueueAddsSessionId(XDMMediaEventType.STATES_UPDATE)
     }
 
-    private fun assertQueueAddsSessionId(forType: XDMMediaEventType, overwritePath: String) {
+    private fun assertQueueAddsSessionId(forType: XDMMediaEventType) {
         // MediaState needs to be valid to process event queue
         `when`(mockState.isValid).thenReturn(true)
 
@@ -581,11 +583,25 @@ class MediaRealTimeSessionTests {
         dispatchedEvent?.let { dispatched ->
             val flatMap = flatten(dispatched.eventData)
             assertEquals(
+                "[${forType.value}] event name does not match.",
+                "Edge Media - ${XDMMediaEventType.getTypeString(forType)}",
+                dispatched.name
+            )
+            assertEquals(
+                "[${forType.value}] event type does not match.",
+                XDMMediaEventType.getTypeString(forType),
+                flatMap["xdm.eventType"]
+            )
+            assertEquals(
                 "[${forType.value}] backend session ID does not match.",
                 "sessionId",
                 flatMap["xdm.mediaCollection.sessionID"]
             )
-            // TODO assert path overwrite
+            assertEquals(
+                "[${forType.value}] overwrite path does not match.",
+                "/va/v1/${forType.value}",
+                flatMap["request.path"]
+            )
         }
     }
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.media.internal
 
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,7 +33,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = true
 
-        val event = XDMMediaEvent(XDMMediaSchema())
+        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY))
         session.queue(event)
 
         assertTrue(session.handleQueueEventCalled)
@@ -44,7 +45,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = false
 
-        val event = XDMMediaEvent(XDMMediaSchema())
+        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY))
         session.queue(event)
 
         assertFalse(session.handleQueueEventCalled)

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.edge.media.internal
 
 import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaCollection
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
@@ -22,6 +23,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.mock
+import java.util.*
 
 class MediaSessionTests {
     private val id = "testSessionId"
@@ -33,7 +35,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = true
 
-        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY))
+        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY, Date(), XDMMediaCollection()))
         session.queue(event)
 
         assertTrue(session.handleQueueEventCalled)
@@ -45,7 +47,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = false
 
-        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY))
+        val event = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY, Date(), XDMMediaCollection()))
         session.queue(event)
 
         assertFalse(session.handleQueueEventCalled)

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
@@ -1,0 +1,153 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class MediaSessionTests {
+    private val id = "testSessionId"
+    private var mockState: MediaState = mock(MediaState::class.java)
+    private val dispatcher: (Event) -> Unit = { }
+
+    @Test
+    fun `queue() with active session calls handleQueueEvent`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = true
+
+        val event = XDMMediaEvent()
+        session.queue(event)
+
+        assertTrue(session.handleQueueEventCalled)
+        assertEquals(event, session.handleQueueEventParamXDMMediaEvent)
+    }
+
+    @Test
+    fun `queue() without active session does not call handleQueueEvent`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = false
+
+        val event = XDMMediaEvent()
+        session.queue(event)
+
+        assertFalse(session.handleQueueEventCalled)
+        assertNull(session.handleQueueEventParamXDMMediaEvent)
+    }
+
+    @Test
+    fun `end() with active session calls handleSessionEnd`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = true
+
+        val sessionEndHandler: () -> Unit = { }
+        session.end(sessionEndHandler)
+
+        assertTrue(session.handleSessionEndCalled)
+        assertEquals(sessionEndHandler, session.sessionEndHandler)
+        assertFalse(session.isSessionActive) // end() sets session active to false
+    }
+
+    @Test
+    fun `end() without active session does not call handleSessionEnd`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = false
+
+        val sessionEndHandler: () -> Unit = { }
+        session.end(sessionEndHandler)
+
+        assertFalse(session.handleSessionEndCalled)
+        assertNotEquals(session, session.sessionEndHandler)
+    }
+
+    @Test
+    fun `abort() with active session calls handleSessionAbort`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = true
+
+        val sessionEndHandler: () -> Unit = { }
+        session.abort(sessionEndHandler)
+
+        assertTrue(session.handleSessionAbortCalled)
+        assertEquals(sessionEndHandler, session.sessionEndHandler)
+        assertFalse(session.isSessionActive) // abort() sets session active to false
+    }
+
+    @Test
+    fun `abort() without active session does not call handleSessionAbort`() {
+        val session = SpyMediaSession(id, mockState, dispatcher)
+        session.isSessionActive = false
+
+        val sessionEndHandler: () -> Unit = { }
+        session.end(sessionEndHandler)
+
+        assertFalse(session.handleSessionAbortCalled)
+        assertNotEquals(session, session.sessionEndHandler)
+    }
+
+    private class SpyMediaSession(
+        id: String,
+        state: MediaState,
+        dispatchHandler: (Event) -> Unit
+    ) : MediaSession(
+        id,
+        state,
+        dispatchHandler
+    ) {
+
+        var handleMediaStateUpdateCalled: Boolean = false
+        override fun handleMediaStateUpdate() {
+            handleMediaStateUpdateCalled = true
+        }
+
+        var handleSessionEndCalled: Boolean = false
+        override fun handleSessionEnd() {
+            handleSessionEndCalled = true
+        }
+
+        var handleSessionAbortCalled: Boolean = false
+        override fun handleSessionAbort() {
+            handleSessionAbortCalled = true
+        }
+
+        var handleQueueEventCalled: Boolean = false
+        var handleQueueEventParamXDMMediaEvent: XDMMediaEvent? = null
+        override fun handleQueueEvent(event: XDMMediaEvent) {
+            handleQueueEventCalled = true
+            handleQueueEventParamXDMMediaEvent = event
+        }
+
+        var handleSessionUpdateCalled: Boolean = false
+        var handleSessionUpdateParamRequestEventId: String? = null
+        var handleSessionUpdateParamBackendSessionId: String? = null
+        override fun handleSessionUpdate(requestEventId: String, backendSessionId: String?) {
+            handleSessionUpdateCalled = true
+            handleSessionUpdateParamRequestEventId = requestEventId
+            handleSessionUpdateParamBackendSessionId = backendSessionId
+        }
+
+        var handleErrorResponseCalled: Boolean = false
+        var handleErrorResponseParamRequestEventId: String? = null
+        var handleErrorResponseParamData: Map<String, Any>? = null
+        override fun handleErrorResponse(requestEventId: String, data: Map<String, Any>) {
+            handleErrorResponseCalled = true
+            handleErrorResponseParamRequestEventId = requestEventId
+            handleErrorResponseParamData = data
+        }
+    }
+}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaSessionTests.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.media.internal
 
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -31,7 +32,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = true
 
-        val event = XDMMediaEvent()
+        val event = XDMMediaEvent(XDMMediaSchema())
         session.queue(event)
 
         assertTrue(session.handleQueueEventCalled)
@@ -43,7 +44,7 @@ class MediaSessionTests {
         val session = SpyMediaSession(id, mockState, dispatcher)
         session.isSessionActive = false
 
-        val event = XDMMediaEvent()
+        val event = XDMMediaEvent(XDMMediaSchema())
         session.queue(event)
 
         assertFalse(session.handleQueueEventCalled)

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaTestConstants.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaTestConstants.java
@@ -17,9 +17,8 @@ public final class MediaTestConstants {
 
     static final class Media {
         static final String EVENT_TYPE = "com.adobe.eventType.edgeMedia";
-        static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.requestTracker";
+        static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.createTracker";
         static final String EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventSource.trackMedia";
-        static final String EVENT_SOURCE_SESSION_CREATED = "com.adobe.eventSource.sessionCreated";
         static final String EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session";
 
         static final String MEDIA_TYPE_VIDEO = "video";

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -459,7 +459,7 @@ class XDMPropertyTests {
         mediaCollection.statesEnd = playerStateData
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "advertisingDetails" to expectedAdvertisingDetails,
             "advertisingPodDetails" to expectedAdvertisingPodDetails,
             "chapterDetails" to expectedChapterDetails,
@@ -488,7 +488,7 @@ class XDMPropertyTests {
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "playhead" to 0L,
             "sessionDetails" to expectedSessionDetails,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -507,7 +507,7 @@ class XDMPropertyTests {
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "advertisingPodDetails" to expectedAdvertisingPodDetails,
             "playhead" to 0L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -526,7 +526,7 @@ class XDMPropertyTests {
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "advertisingDetails" to expectedAdvertisingDetails,
             "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -545,7 +545,7 @@ class XDMPropertyTests {
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "chapterDetails" to expectedChapterDetails,
             "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -564,7 +564,7 @@ class XDMPropertyTests {
         mediaCollection.statesStart = playerStateData
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
             "statesStart" to expectedPlayerStateData
@@ -583,7 +583,7 @@ class XDMPropertyTests {
         mediaCollection.statesEnd = playerStateData
 
         val xdm = mediaCollection.serializeToXDM()
-        val expected = mapOf<String, Any>(
+        val expected = mapOf(
             "playhead" to 123L,
             "sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d",
             "statesEnd" to expectedPlayerStateData
@@ -604,8 +604,7 @@ class XDMPropertyTests {
     @Test
     fun `XDMMediaSchema serializeToXDM all properties`() {
         val dateNow = Date()
-        val schema = XDMMediaSchema()
-        schema.eventType = XDMMediaEventType.PLAY
+        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
         schema.timestamp = dateNow
         val mediaCollection = XDMMediaCollection()
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
@@ -624,19 +623,20 @@ class XDMPropertyTests {
     }
 
     @Test
-    fun `XDMMediaSchema serializeToXDM no properties returns empty map`() {
-        val schema = XDMMediaSchema()
+    fun `XDMMediaSchema serializeToXDM no properties returns map with event type`() {
+        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
         val xdm = schema.serializeToXDM()
+        val expected = mapOf(
+            "eventType" to XDMMediaEventType.getTypeString(XDMMediaEventType.PLAY)
+        )
 
-        assertNotNull(xdm)
-        assertTrue(xdm.isEmpty())
+        assertEquals(expected, xdm)
     }
 
     @Test
     fun `XDMMediaEvent serializeToXDM all properties`() {
         val dateNow = Date()
-        val schema = XDMMediaSchema()
-        schema.eventType = XDMMediaEventType.PLAY
+        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
         schema.timestamp = dateNow
         val mediaCollection = XDMMediaCollection()
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -642,9 +642,7 @@ class XDMPropertyTests {
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
         schema.mediaCollection = mediaCollection
 
-        val mediaEvent = XDMMediaEvent()
-        mediaEvent.xdmData = schema
-
+        val mediaEvent = XDMMediaEvent(schema)
         val xdm = mediaEvent.serializeToXDM()
         val expected = mapOf(
             "xdm" to mapOf(
@@ -659,15 +657,6 @@ class XDMPropertyTests {
         // Assert testing all class member properties
         // XDMMediaEvent "request.path" is not a class property but is generated during serializeToXDM
         assertEquals(expected.size - 1, XDMMediaEvent::class.memberProperties.size)
-    }
-
-    @Test
-    fun `XDMMediaEvent serializeToXDM no properties returns empty map`() {
-        val schema = XDMMediaEvent()
-        val xdm = schema.serializeToXDM()
-
-        assertNotNull(xdm)
-        assertTrue(xdm.isEmpty())
     }
 
     private fun getSampleAdvertisingDetails(): Pair<XDMAdvertisingDetails, Map<String, Any>> {

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -11,10 +11,12 @@
 
 package com.adobe.marketing.mobile.edge.media.internal.xdm
 
+import com.adobe.marketing.mobile.util.TimeUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Date
 import kotlin.reflect.full.memberProperties
 
 class XDMPropertyTests {
@@ -594,6 +596,75 @@ class XDMPropertyTests {
     fun `XDMMediaCollection serializeToXDM no properties returns empty map`() {
         val mediaCollection = XDMMediaCollection()
         val xdm = mediaCollection.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMMediaSchema serializeToXDM all properties`() {
+        val dateNow = Date()
+        val schema = XDMMediaSchema()
+        schema.eventType = XDMMediaEventType.PLAY
+        schema.timestamp = dateNow
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        schema.mediaCollection = mediaCollection
+
+        val xdm = schema.serializeToXDM()
+        val expected = mapOf(
+            "eventType" to XDMMediaEventType.getTypeString(XDMMediaEventType.PLAY),
+            "timestamp" to TimeUtils.getISO8601UTCDateWithMilliseconds(dateNow),
+            "mediaCollection" to mapOf("sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d")
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        assertEquals(expected.size, XDMMediaSchema::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMMediaSchema serializeToXDM no properties returns empty map`() {
+        val schema = XDMMediaSchema()
+        val xdm = schema.serializeToXDM()
+
+        assertNotNull(xdm)
+        assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMMediaEvent serializeToXDM all properties`() {
+        val dateNow = Date()
+        val schema = XDMMediaSchema()
+        schema.eventType = XDMMediaEventType.PLAY
+        schema.timestamp = dateNow
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
+        schema.mediaCollection = mediaCollection
+
+        val mediaEvent = XDMMediaEvent()
+        mediaEvent.xdmData = schema
+
+        val xdm = mediaEvent.serializeToXDM()
+        val expected = mapOf(
+            "xdm" to mapOf(
+                "eventType" to XDMMediaEventType.getTypeString(XDMMediaEventType.PLAY),
+                "timestamp" to TimeUtils.getISO8601UTCDateWithMilliseconds(dateNow),
+                "mediaCollection" to mapOf("sessionID" to "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d")
+            ),
+            "request" to mapOf("path" to "/va/v1/${XDMMediaEventType.PLAY.value}")
+        )
+
+        assertEquals(expected, xdm)
+        // Assert testing all class member properties
+        // XDMMediaEvent "request.path" is not a class property but is generated during serializeToXDM
+        assertEquals(expected.size - 1, XDMMediaEvent::class.memberProperties.size)
+    }
+
+    @Test
+    fun `XDMMediaEvent serializeToXDM no properties returns empty map`() {
+        val schema = XDMMediaEvent()
+        val xdm = schema.serializeToXDM()
 
         assertNotNull(xdm)
         assertTrue(xdm.isEmpty())

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -604,11 +604,9 @@ class XDMPropertyTests {
     @Test
     fun `XDMMediaSchema serializeToXDM all properties`() {
         val dateNow = Date()
-        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
-        schema.timestamp = dateNow
         val mediaCollection = XDMMediaCollection()
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
-        schema.mediaCollection = mediaCollection
+        val schema = XDMMediaSchema(XDMMediaEventType.PLAY, dateNow, mediaCollection)
 
         val xdm = schema.serializeToXDM()
         val expected = mapOf(
@@ -623,24 +621,11 @@ class XDMPropertyTests {
     }
 
     @Test
-    fun `XDMMediaSchema serializeToXDM no properties returns map with event type`() {
-        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
-        val xdm = schema.serializeToXDM()
-        val expected = mapOf(
-            "eventType" to XDMMediaEventType.getTypeString(XDMMediaEventType.PLAY)
-        )
-
-        assertEquals(expected, xdm)
-    }
-
-    @Test
     fun `XDMMediaEvent serializeToXDM all properties`() {
         val dateNow = Date()
-        val schema = XDMMediaSchema(XDMMediaEventType.PLAY)
-        schema.timestamp = dateNow
         val mediaCollection = XDMMediaCollection()
         mediaCollection.sessionID = "99cf4e3e7145d8e2b8f4f1e9e1a08cd52518a74091c0b0c611ca97b259e03a4d"
-        schema.mediaCollection = mediaCollection
+        val schema = XDMMediaSchema(XDMMediaEventType.PLAY, dateNow, mediaCollection)
 
         val mediaEvent = XDMMediaEvent(schema)
         val xdm = mediaEvent.serializeToXDM()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds MediaSession and MediaRealTimeSession classes.

- Add abstract class MediaSession and unit tests
- Add MediaRealTimeSession class which extends MediaSession, and unit tests
- MediaRealTimeSession does not dispatch session created response event as it is redundant with the event dispatched from Edge extension.
- Add XDMMediaSchema class to represent top-level XDM Media schema
- Add XDMMediaEvent class which holds "xdm" and "request.path" fields

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
