### PR TITLE
Implemented XDMEventGenerator + Custom Ping Interval + Unit tests (resolves #12, resolves #19)

### DIFF
--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaCollectionHitGenerator.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaCollectionHitGenerator.java
@@ -31,7 +31,7 @@ class MediaCollectionHitGenerator {
     private boolean isTracking;
     private long interval;
     private long refTS;
-    private MediaPlayBackState previousState;
+    private MediaPlaybackState previousState;
     private long previousStateTS;
     private final String refSessionId;
 
@@ -47,7 +47,7 @@ class MediaCollectionHitGenerator {
 
         this.refTS = refTS;
         this.refSessionId = refSessionId;
-        previousState = MediaPlayBackState.Init;
+        previousState = MediaPlaybackState.Init;
         previousStateTS = refTS;
         lastQOEData = new HashMap<>();
         downloadedContent =
@@ -163,7 +163,7 @@ class MediaCollectionHitGenerator {
 
     /** Restart session again after 24 hr timeout or idle timeout recovered. */
     void processSessionRestart() {
-        previousState = MediaPlayBackState.Init;
+        previousState = MediaPlaybackState.Init;
         previousStateTS = refTS;
 
         lastQOEData.clear();
@@ -218,7 +218,7 @@ class MediaCollectionHitGenerator {
             return;
         }
 
-        MediaPlayBackState currentState = getPlaybackState();
+        MediaPlaybackState currentState = getPlaybackState();
 
         if (previousState != currentState || doFlush) {
             String eventType = getMediaCollectionEvent(currentState);
@@ -333,35 +333,35 @@ class MediaCollectionHitGenerator {
         }
     }
 
-    MediaPlayBackState getPlaybackState() {
-        if (mediaContext.isInState(MediaPlayBackState.Buffer)) {
-            return MediaPlayBackState.Buffer;
-        } else if (mediaContext.isInState(MediaPlayBackState.Seek)) {
-            return MediaPlayBackState.Seek;
-        } else if (mediaContext.isInState(MediaPlayBackState.Play)) {
-            return MediaPlayBackState.Play;
-        } else if (mediaContext.isInState(MediaPlayBackState.Pause)) {
-            return MediaPlayBackState.Pause;
-        } else if (mediaContext.isInState(MediaPlayBackState.Stall)) {
-            return MediaPlayBackState.Stall;
+    MediaPlaybackState getPlaybackState() {
+        if (mediaContext.isInState(MediaPlaybackState.Buffer)) {
+            return MediaPlaybackState.Buffer;
+        } else if (mediaContext.isInState(MediaPlaybackState.Seek)) {
+            return MediaPlaybackState.Seek;
+        } else if (mediaContext.isInState(MediaPlaybackState.Play)) {
+            return MediaPlaybackState.Play;
+        } else if (mediaContext.isInState(MediaPlaybackState.Pause)) {
+            return MediaPlaybackState.Pause;
+        } else if (mediaContext.isInState(MediaPlaybackState.Stall)) {
+            return MediaPlaybackState.Stall;
         } else {
-            return MediaPlayBackState.Init;
+            return MediaPlaybackState.Init;
         }
     }
 
-    String getMediaCollectionEvent(final MediaPlayBackState state) {
-        if (state == MediaPlayBackState.Buffer) {
+    String getMediaCollectionEvent(final MediaPlaybackState state) {
+        if (state == MediaPlaybackState.Buffer) {
             return MediaCollectionConstants.EventType.BUFFER_START;
-        } else if (state == MediaPlayBackState.Seek) {
+        } else if (state == MediaPlaybackState.Seek) {
             return MediaCollectionConstants.EventType.PAUSE_START;
-        } else if (state == MediaPlayBackState.Play) {
+        } else if (state == MediaPlaybackState.Play) {
             return MediaCollectionConstants.EventType.PLAY;
-        } else if (state == MediaPlayBackState.Pause) {
+        } else if (state == MediaPlaybackState.Pause) {
             return MediaCollectionConstants.EventType.PAUSE_START;
-        } else if (state == MediaPlayBackState.Stall) {
+        } else if (state == MediaPlaybackState.Stall) {
             // Stall not supported by backend we just send Play event for it
             return MediaCollectionConstants.EventType.PLAY;
-        } else if (state == MediaPlayBackState.Init) {
+        } else if (state == MediaPlaybackState.Init) {
             // We should never hit this condition as there is not event to denote init.
             // Ping without any previous playback state denotes init.
             return MediaCollectionConstants.EventType.PING;

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaContext.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaContext.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-enum MediaPlayBackState {
+enum MediaPlaybackState {
     Init,
     Play,
     Pause,
@@ -60,7 +60,7 @@ class MediaContext {
     private QoEInfo qoeInfo;
     private Map<String, String> mediaMetadata, adMetadata, chapterMetadata;
     private boolean buffering, seeking;
-    private MediaPlayBackState playState;
+    private MediaPlaybackState playState;
     private double playhead;
     private final Map<String, Boolean> states;
 
@@ -89,7 +89,7 @@ class MediaContext {
             mediaMetadata = new HashMap<>(metadata);
         }
 
-        playState = MediaPlayBackState.Init;
+        playState = MediaPlaybackState.Init;
         playhead = 0;
     }
 
@@ -218,7 +218,7 @@ class MediaContext {
         chapterMetadata.clear();
     }
 
-    void enterState(final MediaPlayBackState state) {
+    void enterState(final MediaPlaybackState state) {
         Log.trace(MediaInternalConstants.LOG_TAG, LOG_TAG, "enterState - " + state.toString());
 
         switch (state) {
@@ -246,7 +246,7 @@ class MediaContext {
         }
     }
 
-    void exitState(final MediaPlayBackState state) {
+    void exitState(final MediaPlaybackState state) {
         Log.trace(MediaInternalConstants.LOG_TAG, LOG_TAG, "exitState - " + state.toString());
 
         switch (state) {
@@ -268,7 +268,7 @@ class MediaContext {
         }
     }
 
-    boolean isInState(final MediaPlayBackState state) {
+    boolean isInState(final MediaPlaybackState state) {
         boolean retVal = false;
 
         switch (state) {
@@ -294,9 +294,9 @@ class MediaContext {
     }
 
     boolean isIdle() {
-        return !isInState(MediaPlayBackState.Play)
-                || isInState(MediaPlayBackState.Buffer)
-                || isInState(MediaPlayBackState.Seek);
+        return !isInState(MediaPlaybackState.Play)
+                || isInState(MediaPlaybackState.Buffer)
+                || isInState(MediaPlaybackState.Seek);
     }
 
     boolean startState(final StateInfo stateInfo) {
@@ -310,7 +310,7 @@ class MediaContext {
             return false;
         }
 
-        if (isInState(stateInfo)) {
+        if (isInPlayerState(stateInfo)) {
             Log.debug(
                     MediaInternalConstants.LOG_TAG,
                     LOG_TAG,
@@ -324,7 +324,7 @@ class MediaContext {
     }
 
     boolean endState(final StateInfo stateInfo) {
-        if (!isInState(stateInfo)) {
+        if (!isInPlayerState(stateInfo)) {
             Log.debug(
                     MediaInternalConstants.LOG_TAG,
                     LOG_TAG,
@@ -337,7 +337,7 @@ class MediaContext {
         return true;
     }
 
-    boolean isInState(final StateInfo stateInfo) {
+    boolean isInPlayerState(final StateInfo stateInfo) {
         String stateName = stateInfo.getStateName();
         return states.containsKey(stateName) && states.get(stateName);
     }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventTracker.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventTracker.java
@@ -223,10 +223,10 @@ class MediaEventTracker implements MediaEventTracking {
     IMediaRuleCallback isInChapter = (rule, context) -> mediaContext.isInChapter();
 
     IMediaRuleCallback isInBuffering =
-            (rule, context) -> mediaContext.isInState(MediaPlayBackState.Buffer);
+            (rule, context) -> mediaContext.isInState(MediaPlaybackState.Buffer);
 
     IMediaRuleCallback isInSeeking =
-            (rule, context) -> mediaContext.isInState(MediaPlayBackState.Seek);
+            (rule, context) -> mediaContext.isInState(MediaPlaybackState.Seek);
 
     IMediaRuleCallback isValidMediaInfo =
             (rule, context) -> {
@@ -331,7 +331,7 @@ class MediaEventTracker implements MediaEventTracking {
                 Map<String, Object> info =
                         DataReader.optTypedMap(Object.class, context, KEY_INFO, null);
                 StateInfo stateInfo = StateInfo.fromObjectMap(info);
-                return mediaContext.isInState(stateInfo);
+                return mediaContext.isInPlayerState(stateInfo);
             };
 
     IMediaRuleCallback allowStateTrack =
@@ -454,10 +454,10 @@ class MediaEventTracker implements MediaEventTracking {
                 int ruleName = rule.getName();
 
                 if (ruleName == MediaRuleName.AdStart.ordinal()) {
-                    if (mediaContext.isInState(MediaPlayBackState.Init)
-                            && !mediaContext.isInState(MediaPlayBackState.Buffer)
-                            && !mediaContext.isInState(MediaPlayBackState.Seek)) {
-                        mediaContext.enterState(MediaPlayBackState.Play);
+                    if (mediaContext.isInState(MediaPlaybackState.Init)
+                            && !mediaContext.isInState(MediaPlaybackState.Buffer)
+                            && !mediaContext.isInState(MediaPlaybackState.Seek)) {
+                        mediaContext.enterState(MediaPlaybackState.Play);
                     }
                 }
 
@@ -465,8 +465,8 @@ class MediaEventTracker implements MediaEventTracking {
                 // we manually switch to pause as there is not way to go back to init state.
                 if (ruleName == MediaRuleName.BufferComplete.ordinal()
                         || ruleName == MediaRuleName.SeekComplete.ordinal()) {
-                    if (mediaContext.isInState(MediaPlayBackState.Init)) {
-                        mediaContext.enterState(MediaPlayBackState.Pause);
+                    if (mediaContext.isInState(MediaPlaybackState.Init)) {
+                        mediaContext.enterState(MediaPlaybackState.Pause);
                     }
                 }
 
@@ -620,26 +620,26 @@ class MediaEventTracker implements MediaEventTracking {
 
     IMediaRuleCallback cmdPlay =
             (rule, context) -> {
-                mediaContext.enterState(MediaPlayBackState.Play);
+                mediaContext.enterState(MediaPlaybackState.Play);
                 return true;
             };
 
     IMediaRuleCallback cmdPause =
             (rule, context) -> {
-                mediaContext.enterState(MediaPlayBackState.Pause);
+                mediaContext.enterState(MediaPlaybackState.Pause);
                 return true;
             };
 
     IMediaRuleCallback cmdBufferStart =
             (rule, context) -> {
-                mediaContext.enterState(MediaPlayBackState.Buffer);
+                mediaContext.enterState(MediaPlaybackState.Buffer);
                 return true;
             };
 
     IMediaRuleCallback cmdBufferComplete =
             (rule, context) -> {
-                if (mediaContext.isInState(MediaPlayBackState.Buffer)) {
-                    mediaContext.exitState(MediaPlayBackState.Buffer);
+                if (mediaContext.isInState(MediaPlaybackState.Buffer)) {
+                    mediaContext.exitState(MediaPlaybackState.Buffer);
                 }
 
                 return true;
@@ -647,14 +647,14 @@ class MediaEventTracker implements MediaEventTracking {
 
     IMediaRuleCallback cmdSeekStart =
             (rule, context) -> {
-                mediaContext.enterState(MediaPlayBackState.Seek);
+                mediaContext.enterState(MediaPlaybackState.Seek);
                 return true;
             };
 
     IMediaRuleCallback cmdSeekComplete =
             (rule, context) -> {
-                if (mediaContext.isInState(MediaPlayBackState.Seek)) {
-                    mediaContext.exitState(MediaPlayBackState.Seek);
+                if (mediaContext.isInState(MediaPlaybackState.Seek)) {
+                    mediaContext.exitState(MediaPlaybackState.Seek);
                 }
 
                 return true;

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -210,4 +210,10 @@ final class MediaInternalConstants {
 
         private ErrorSource() {}
     }
+
+    static final class PingInterval {
+        static final int REALTIME_TRACKING_MS = 10 * 1000; // 10 sec
+
+        private PingInterval() {}
+    }
 }

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGenerator.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGenerator.kt
@@ -24,12 +24,13 @@ import com.adobe.marketing.mobile.util.DataReader
 import com.adobe.marketing.mobile.util.StringUtils
 import java.util.Date
 
-internal class MediaXDMEventGenerator(context: MediaContext, eventProcessor: MediaEventProcessor, trackerConfig: Map<String, Any>, refTS: Long) {
+internal class MediaXDMEventGenerator(
+    private val mediaContext: MediaContext,
+    private val mediaEventProcessor: MediaEventProcessor,
+    private val trackerConfig: Map<String, Any>,
+    private var refTS: Long
+) {
     private val SOURCE_TAG = "MediaExperienceEventGenerator"
-    private var mediaContext = context
-    private val mediaEventProcessor = eventProcessor
-    private val trackerConfig = trackerConfig
-    private var refTS: Long = refTS
     private var lastReportedQoe: XDMQoeDataDetails? = null
     private var isTracking: Boolean = false
     private var currentPlaybackState: MediaPlaybackState? = null
@@ -43,15 +44,15 @@ internal class MediaXDMEventGenerator(context: MediaContext, eventProcessor: Med
     }
 
     fun processSessionStart(forceResume: Boolean = false) {
-        var sessionDetails = MediaXDMEventHelper.generateSessionDetails(mediaContext.mediaInfo, mediaContext.mediaMetadata, forceResume)
+        val sessionDetails = MediaXDMEventHelper.generateSessionDetails(mediaContext.mediaInfo, mediaContext.mediaMetadata, forceResume)
         val customMetadata = MediaXDMEventHelper.generateMediaCustomMetadata(mediaContext.mediaMetadata)
 
-        var channel = DataReader.optString(trackerConfig, MediaConstants.TrackerConfig.CHANNEL, null)
+        val channel = DataReader.optString(trackerConfig, MediaConstants.TrackerConfig.CHANNEL, null)
         if (!StringUtils.isNullOrEmpty(channel)) {
             sessionDetails.channel = channel
         }
 
-        var mediaCollection = XDMMediaCollection()
+        val mediaCollection = XDMMediaCollection()
         mediaCollection.sessionDetails = sessionDetails
         mediaCollection.customMetadata = customMetadata
 

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGenerator.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGenerator.kt
@@ -1,0 +1,306 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.edge.media.MediaConstants
+import com.adobe.marketing.mobile.edge.media.internal.MediaInternalConstants.LOG_TAG
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMErrorDetails
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaCollection
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMQoeDataDetails
+import com.adobe.marketing.mobile.services.Log
+import com.adobe.marketing.mobile.util.DataReader
+import com.adobe.marketing.mobile.util.StringUtils
+import java.util.Date
+
+internal class MediaXDMEventGenerator(context: MediaContext, eventProcessor: MediaEventProcessor, trackerConfig: Map<String, Any>, refTS: Long) {
+    private val SOURCE_TAG = "MediaExperienceEventGenerator"
+    private var mediaContext = context
+    private val mediaEventProcessor = eventProcessor
+    private val trackerConfig = trackerConfig
+    private var refTS: Long = refTS
+    private var lastReportedQoe: XDMQoeDataDetails? = null
+    private var isTracking: Boolean = false
+    private var currentPlaybackState: MediaPlaybackState? = null
+    private var currentPlaybackStateStartRefTS: Long = refTS
+    private val allowedAdPingIntervalRangeInSeconds = 1..10
+    private val allowedMainPingIntervalRangeInSeconds = 10..50
+    private var sessionId: String = ""
+
+    init {
+        startTrackingSession()
+    }
+
+    fun processSessionStart(forceResume: Boolean = false) {
+        var sessionDetails = MediaXDMEventHelper.generateSessionDetails(mediaContext.mediaInfo, mediaContext.mediaMetadata, forceResume)
+        val customMetadata = MediaXDMEventHelper.generateMediaCustomMetadata(mediaContext.mediaMetadata)
+
+        var channel = DataReader.optString(trackerConfig, MediaConstants.TrackerConfig.CHANNEL, null)
+        if (!StringUtils.isNullOrEmpty(channel)) {
+            sessionDetails.channel = channel
+        }
+
+        var mediaCollection = XDMMediaCollection()
+        mediaCollection.sessionDetails = sessionDetails
+        mediaCollection.customMetadata = customMetadata
+
+        addGenericDataAndProcess(XDMMediaEventType.SESSION_START, mediaCollection)
+    }
+
+    fun processSessionComplete() {
+        addGenericDataAndProcess(XDMMediaEventType.SESSION_COMPLETE, null)
+        endTrackingSession()
+    }
+
+    fun processSessionEnd() {
+        addGenericDataAndProcess(XDMMediaEventType.SESSION_END, null)
+        endTrackingSession()
+    }
+
+    fun processAdBreakStart() {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.advertisingPodDetails = MediaXDMEventHelper.generateAdvertisingPodDetails(mediaContext.adBreakInfo)
+
+        addGenericDataAndProcess(XDMMediaEventType.AD_BREAK_START, mediaCollection)
+    }
+
+    fun processAdBreakComplete() {
+        addGenericDataAndProcess(XDMMediaEventType.AD_BREAK_COMPLETE, null)
+    }
+
+    fun processAdBreakSkip() {
+        addGenericDataAndProcess(XDMMediaEventType.AD_BREAK_COMPLETE, null)
+    }
+
+    fun processAdStart() {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.advertisingDetails = MediaXDMEventHelper.generateAdvertisingDetails(mediaContext.adInfo, mediaContext.adMetadata)
+        mediaCollection.customMetadata = MediaXDMEventHelper.generateAdCustomMetadata(mediaContext.adMetadata)
+
+        addGenericDataAndProcess(XDMMediaEventType.AD_START, mediaCollection)
+    }
+
+    fun processAdComplete() {
+        addGenericDataAndProcess(XDMMediaEventType.AD_COMPLETE, null)
+    }
+
+    fun processAdSkip() {
+        addGenericDataAndProcess(XDMMediaEventType.AD_SKIP, null)
+    }
+
+    fun processChapterStart() {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.chapterDetails = MediaXDMEventHelper.generateChapterDetails(mediaContext.chapterInfo)
+        mediaCollection.customMetadata = MediaXDMEventHelper.generateChapterMetadata(mediaContext.chapterMetadata)
+
+        addGenericDataAndProcess(XDMMediaEventType.CHAPTER_START, mediaCollection)
+    }
+
+    fun processChapterComplete() {
+        addGenericDataAndProcess(XDMMediaEventType.CHAPTER_COMPLETE, null)
+    }
+
+    fun processChapterSkip() {
+        addGenericDataAndProcess(XDMMediaEventType.CHAPTER_SKIP, null)
+    }
+
+    // / End media session after 24 hr timeout or idle timeout(30 mins).
+    fun processSessionAbort() {
+        processSessionEnd()
+    }
+
+    // / Restart session again after 24 hr timeout or idle timeout recovered.
+    fun processSessionRestart() {
+        currentPlaybackState = MediaPlaybackState.Init
+        currentPlaybackStateStartRefTS = refTS
+
+        lastReportedQoe = null
+        startTrackingSession()
+        processSessionStart(forceResume = true)
+
+        if (mediaContext.chapterInfo != null) {
+            processChapterStart()
+        }
+
+        if (mediaContext.adBreakInfo != null) {
+            processAdBreakStart()
+        }
+
+        if (mediaContext.adInfo != null) {
+            processAdStart()
+        }
+
+        for (state in mediaContext.activeTrackedStates) {
+            processStateStart(state)
+        }
+
+        processPlayback(doFlush = false)
+    }
+
+    fun processBitrateChange() {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.qoeDataDetails = MediaXDMEventHelper.generateQoEDataDetails(mediaContext.qoEInfo)
+
+        addGenericDataAndProcess(XDMMediaEventType.BITRATE_CHANGE, mediaCollection)
+    }
+
+    fun processError(errorId: String) {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.errorDetails = XDMErrorDetails(errorId, MediaInternalConstants.ErrorSource.PLAYER)
+
+        addGenericDataAndProcess(XDMMediaEventType.ERROR, mediaCollection)
+    }
+
+    fun processPlayback(doFlush: Boolean = false) {
+        val reportingInterval = getReportingIntervalFromTrackerConfig(isAdStart = (mediaContext.adInfo != null))
+
+        if (!isTracking) {
+            return
+        }
+
+        val newPlaybackState = getPlaybackState()
+
+        if (currentPlaybackState != newPlaybackState || doFlush) {
+            val eventType = getMediaEventForPlaybackState(newPlaybackState)
+
+            addGenericDataAndProcess(eventType, null)
+            currentPlaybackState = newPlaybackState
+            currentPlaybackStateStartRefTS = refTS
+        } else if ((newPlaybackState == currentPlaybackState) && (refTS - currentPlaybackStateStartRefTS >= reportingInterval)) {
+            // If the ts difference is more than interval we need to send it as multiple pings
+            addGenericDataAndProcess(XDMMediaEventType.PING, null)
+            currentPlaybackStateStartRefTS = refTS
+        }
+    }
+
+    fun processStateStart(stateInfo: StateInfo) {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.statesStart = MediaXDMEventHelper.generateStateDetails(listOf(stateInfo))
+
+        addGenericDataAndProcess(XDMMediaEventType.STATES_UPDATE, mediaCollection)
+    }
+
+    fun processStateEnd(stateInfo: StateInfo) {
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.statesEnd = MediaXDMEventHelper.generateStateDetails(listOf(stateInfo))
+
+        addGenericDataAndProcess(XDMMediaEventType.STATES_UPDATE, mediaCollection)
+    }
+
+    fun setRefTS(ts: Long) {
+        this.refTS = ts
+    }
+
+    // / Signals event processor to start a new media session.
+    private fun startTrackingSession() {
+        sessionId = mediaEventProcessor.createSession()
+        isTracking = true
+        Log.debug(LOG_TAG, SOURCE_TAG, "Started a new session with id ($sessionId)")
+    }
+
+    private fun endTrackingSession() {
+        if (isTracking) {
+            Log.debug(LOG_TAG, SOURCE_TAG, "Ending the session with id ($sessionId).")
+            mediaEventProcessor.endSession(sessionId)
+            isTracking = false
+        }
+    }
+
+    // / Prepares the XDM formatted data and creates a`MediaXDMEvent`, which is then sent to `MediaEventProcessor` for processing.
+    // /  - Parameters:
+    // /   - eventType: A `XDMMediaEventType` enum representing the XDM formatted name of the media event.
+    // /   - mediaCollection: A  `XDMMediaCollection` object which is a XDM formatted object with some fields populated depending on the media event.
+    private fun addGenericDataAndProcess(eventType: XDMMediaEventType, mediaCollection: XDMMediaCollection?) {
+        if (!isTracking) {
+            Log.debug(LOG_TAG, SOURCE_TAG, "Dropping hit as session ($sessionId) is no longer being actively tracked.")
+            return
+        }
+
+        val mediaCollection = mediaCollection ?: XDMMediaCollection()
+
+        // For bitrate change events and error events, use the qoe data in the current event being generated. For other events check MediaContext QoE object for latest QoE data updates.
+        mediaCollection.qoeDataDetails = getQoEForCurrentEvent(mediaCollection.qoeDataDetails)
+        // Add playhead details
+        mediaCollection.playhead = mediaContext.playhead.toLong()
+
+        val timestampAsDate = Date(refTS)
+        val xdmEvent = XDMMediaEvent(XDMMediaSchema(eventType, timestampAsDate, mediaCollection))
+
+        mediaEventProcessor.processEvent(sessionId, xdmEvent)
+    }
+
+    // / Gets the XDM formatted QoE data for the current event.
+    // /  - Parameter qoe: A `XDMQoeDataDetails` object
+    // /  - Returns:XDMFormatted QoE data if the current event has QoE Data or if the MediaContext has QoE data which is not yet reported to the backend. Otherwise it returns nil.
+    private fun getQoEForCurrentEvent(qoe: XDMQoeDataDetails?): XDMQoeDataDetails? {
+        // Cache and return the passed in QoE object if it is not nil
+        if (qoe != null && qoe.isValid()) {
+            lastReportedQoe = qoe
+            return qoe
+        }
+        // If the passed QoE data object is nil, get the QoE data cached by the MediaContext class and convert to XDM formatted object.
+        val mediaContextQoe = MediaXDMEventHelper.generateQoEDataDetails(mediaContext.qoEInfo)
+        // If the QoE data cached by the MediaContext class is different than the last reported QoE data, return the MediaContext cached QoE data to be sent to the backend
+        if (lastReportedQoe != mediaContextQoe) {
+            lastReportedQoe = mediaContextQoe
+            return mediaContextQoe
+        }
+
+        // Return null if the current event does not have any QoE data and the latest QoE data has been already reported
+        return null
+    }
+
+    private fun getPlaybackState(): MediaPlaybackState {
+        return if (mediaContext.isInState(MediaPlaybackState.Buffer)) {
+            MediaPlaybackState.Buffer
+        } else if (mediaContext.isInState(MediaPlaybackState.Seek)) {
+            MediaPlaybackState.Pause
+        } else if (mediaContext.isInState(MediaPlaybackState.Play)) {
+            MediaPlaybackState.Play
+        } else if (mediaContext.isInState(MediaPlaybackState.Pause)) {
+            MediaPlaybackState.Pause
+        } else {
+            MediaPlaybackState.Init
+        }
+    }
+
+    private fun getMediaEventForPlaybackState(state: MediaPlaybackState): XDMMediaEventType {
+        return when (state) {
+            MediaPlaybackState.Buffer -> XDMMediaEventType.BUFFER_START
+            MediaPlaybackState.Seek -> XDMMediaEventType.PAUSE_START
+            MediaPlaybackState.Pause -> XDMMediaEventType.PAUSE_START
+            MediaPlaybackState.Play -> XDMMediaEventType.PLAY
+            else -> XDMMediaEventType.PING
+        }
+    }
+
+    // / Gets the custom reporting interval set in the tracker configuration. Valid custom main ping interval range is (10 seconds - 50 seconds) and valid ad ping interval is (1 second - 10 seconds)
+    // / - Parameter isAdStart: A Boolean  when true denotes reporting interval is needed for Ad content or denotes Main content when false.
+    // / - Return: the custom interval in `MILLISECONDS` if found in tracker configuration. Returns the default `MediaConstants.PingInterval.REALTIME_TRACKING` if the custom values are invalid or not found
+    private fun getReportingIntervalFromTrackerConfig(isAdStart: Boolean = false): Int {
+        if (isAdStart) {
+            val customAdPingInterval = DataReader.optInt(trackerConfig, MediaConstants.TrackerConfig.AD_PING_INTERVAL, 0)
+            if (allowedAdPingIntervalRangeInSeconds.contains(customAdPingInterval)) {
+                return customAdPingInterval * 1000 // convert to Milliseconds
+            }
+        } else {
+            val customMainPingInterval = DataReader.optInt(trackerConfig, MediaConstants.TrackerConfig.MAIN_PING_INTERVAL, 0)
+            if (allowedMainPingIntervalRangeInSeconds.contains(customMainPingInterval)) {
+                return customMainPingInterval * 1000 // convert to Milliseconds
+            }
+        }
+
+        return MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMQoeDataDetails.kt
@@ -39,4 +39,8 @@ internal data class XDMQoeDataDetails(
 
         return map.toMap()
     }
+
+    fun isValid(): Boolean {
+        return bitrate != null && droppedFrames != null && framesPerSecond != null && timeToStart != null
+    }
 }

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
@@ -92,6 +92,15 @@ public class MediaConstants {
         private PlayerState() {}
     }
 
+    /** These constant strings define configuration for tracker. */
+    public static final class TrackerConfig {
+        public static final String CHANNEL = "config.channel";
+        public static final String AD_PING_INTERVAL = "config.adpinginterval";
+        public static final String MAIN_PING_INTERVAL = "config.mainpinginterval";
+
+        private TrackerConfig() {}
+    }
+
     /** These constant strings define video/ad info keys used for MediaObject. */
     public static final class MediaObjectKey {
 

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaCollectionHitGeneratorTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaCollectionHitGeneratorTests.java
@@ -390,7 +390,7 @@ public class MediaCollectionHitGeneratorTests {
 
         mediaContext.setChapterInfo(chapterInfo, chapterMetadata);
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
         hitGenerator.processSessionRestart();
 
@@ -510,7 +510,7 @@ public class MediaCollectionHitGeneratorTests {
 
         mediaContext.setChapterInfo(chapterInfo, chapterMetadata);
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
         hitGenerator.processSessionRestart();
 
@@ -611,7 +611,7 @@ public class MediaCollectionHitGeneratorTests {
     public void test_ProcessIdleCompleteStateTrackingResumesAfterIdle() {
         StateInfo stateInfo = StateInfo.create("fullscreen");
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
         mediaContext.startState(stateInfo);
 
@@ -678,7 +678,7 @@ public class MediaCollectionHitGeneratorTests {
     public void test_ProcessIdleCompleteNoActiveStates() {
         StateInfo stateInfo = StateInfo.create("fullscreen");
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
         mediaContext.startState(stateInfo);
 
@@ -730,7 +730,7 @@ public class MediaCollectionHitGeneratorTests {
     public void test_ProcessIdleCompleteStateTrackingResumesAfterIdle2() {
         StateInfo stateInfo = StateInfo.create("fullscreen");
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
         mediaContext.startState(stateInfo);
 
@@ -803,7 +803,7 @@ public class MediaCollectionHitGeneratorTests {
         assertEquals(0, hitProcessor.hitCountfromActiveSession());
 
         {
-            mediaContext.enterState(MediaPlayBackState.Play);
+            mediaContext.enterState(MediaPlaybackState.Play);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -821,7 +821,7 @@ public class MediaCollectionHitGeneratorTests {
         }
 
         {
-            mediaContext.enterState(MediaPlayBackState.Buffer);
+            mediaContext.enterState(MediaPlaybackState.Buffer);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -839,7 +839,7 @@ public class MediaCollectionHitGeneratorTests {
         }
 
         {
-            mediaContext.exitState(MediaPlayBackState.Buffer);
+            mediaContext.exitState(MediaPlaybackState.Buffer);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -857,7 +857,7 @@ public class MediaCollectionHitGeneratorTests {
         }
 
         {
-            mediaContext.enterState(MediaPlayBackState.Seek);
+            mediaContext.enterState(MediaPlaybackState.Seek);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -875,7 +875,7 @@ public class MediaCollectionHitGeneratorTests {
         }
 
         {
-            mediaContext.exitState(MediaPlayBackState.Seek);
+            mediaContext.exitState(MediaPlaybackState.Seek);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -893,7 +893,7 @@ public class MediaCollectionHitGeneratorTests {
         }
 
         {
-            mediaContext.enterState(MediaPlayBackState.Pause);
+            mediaContext.enterState(MediaPlaybackState.Pause);
             hitGenerator.processPlayback(false);
             assertEquals(1, hitProcessor.hitCountfromActiveSession());
 
@@ -987,7 +987,7 @@ public class MediaCollectionHitGeneratorTests {
         hitProcessor.clearHitsFromActionSession();
 
         {
-            mediaContext.enterState(MediaPlayBackState.Play);
+            mediaContext.enterState(MediaPlaybackState.Play);
             hitGenerator.processPlayback(false);
             Map<String, Object> qoeData = MediaCollectionHelper.extractQoEData(mediaContext);
 
@@ -1090,7 +1090,7 @@ public class MediaCollectionHitGeneratorTests {
         hitProcessor.clearHitsFromActionSession();
 
         {
-            mediaContext.enterState(MediaPlayBackState.Play);
+            mediaContext.enterState(MediaPlaybackState.Play);
             hitGenerator.processPlayback(false);
             Map<String, Object> qoeData = MediaCollectionHelper.extractQoEData(mediaContext);
 
@@ -1119,7 +1119,7 @@ public class MediaCollectionHitGeneratorTests {
 
     @Test
     public void test_processPlaybackSameState() {
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
         hitGenerator.processPlayback(false);
 
         assertEquals(1, hitProcessor.hitCountfromActiveSession());
@@ -1151,7 +1151,7 @@ public class MediaCollectionHitGeneratorTests {
                 new MediaCollectionHitGenerator(
                         mediaContext, hitProcessor, config, 0, refSessionId);
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
         hitGenerator.processPlayback(false);
 
         assertEquals(1, hitProcessor.hitCountfromActiveSession());
@@ -1245,7 +1245,7 @@ public class MediaCollectionHitGeneratorTests {
 
     @Test
     public void test_processPlaybackSameStateTimeout() {
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
         hitGenerator.processPlayback(false);
 
         assertEquals(1, hitProcessor.hitCountfromActiveSession());
@@ -1280,7 +1280,7 @@ public class MediaCollectionHitGeneratorTests {
 
     @Test
     public void test_processPlaybackFlush() {
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
         hitGenerator.processPlayback(true);
 
         assertEquals(1, hitProcessor.hitCountfromActiveSession());
@@ -1469,17 +1469,17 @@ public class MediaCollectionHitGeneratorTests {
 
     @Test
     public void test_getPlaybackState_mediaContextState() {
-        List<MediaPlayBackState> playbackStates = new ArrayList<>();
-        playbackStates.add(MediaPlayBackState.Init);
-        playbackStates.add(MediaPlayBackState.Play);
-        playbackStates.add(MediaPlayBackState.Pause);
-        playbackStates.add(MediaPlayBackState.Seek);
-        playbackStates.add(MediaPlayBackState.Buffer);
-        playbackStates.add(MediaPlayBackState.Stall);
+        List<MediaPlaybackState> playbackStates = new ArrayList<>();
+        playbackStates.add(MediaPlaybackState.Init);
+        playbackStates.add(MediaPlaybackState.Play);
+        playbackStates.add(MediaPlaybackState.Pause);
+        playbackStates.add(MediaPlaybackState.Seek);
+        playbackStates.add(MediaPlaybackState.Buffer);
+        playbackStates.add(MediaPlaybackState.Stall);
 
-        for (MediaPlayBackState state : playbackStates) {
+        for (MediaPlaybackState state : playbackStates) {
             mediaContext.enterState(state);
-            MediaPlayBackState playBackState = hitGenerator.getPlaybackState();
+            MediaPlaybackState playBackState = hitGenerator.getPlaybackState();
             assertEquals(state, playBackState);
             mediaContext.exitState(state);
         }
@@ -1487,29 +1487,29 @@ public class MediaCollectionHitGeneratorTests {
 
     @Test
     public void test_getMediaCollectionEvent_forMediaPlaybackState() {
-        Map<MediaPlayBackState, String> playBackStateToMediaCollectionEventMap = new HashMap<>();
+        Map<MediaPlaybackState, String> playBackStateToMediaCollectionEventMap = new HashMap<>();
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Init, MediaCollectionConstants.EventType.PING);
+                MediaPlaybackState.Init, MediaCollectionConstants.EventType.PING);
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Play, MediaCollectionConstants.EventType.PLAY);
+                MediaPlaybackState.Play, MediaCollectionConstants.EventType.PLAY);
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Pause, MediaCollectionConstants.EventType.PAUSE_START);
+                MediaPlaybackState.Pause, MediaCollectionConstants.EventType.PAUSE_START);
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Buffer, MediaCollectionConstants.EventType.BUFFER_START);
+                MediaPlaybackState.Buffer, MediaCollectionConstants.EventType.BUFFER_START);
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Seek, MediaCollectionConstants.EventType.PAUSE_START);
+                MediaPlaybackState.Seek, MediaCollectionConstants.EventType.PAUSE_START);
         playBackStateToMediaCollectionEventMap.put(
-                MediaPlayBackState.Stall, MediaCollectionConstants.EventType.PLAY);
+                MediaPlaybackState.Stall, MediaCollectionConstants.EventType.PLAY);
 
-        List<MediaPlayBackState> playbackStates = new ArrayList<>();
-        playbackStates.add(MediaPlayBackState.Init);
-        playbackStates.add(MediaPlayBackState.Play);
-        playbackStates.add(MediaPlayBackState.Pause);
-        playbackStates.add(MediaPlayBackState.Seek);
-        playbackStates.add(MediaPlayBackState.Buffer);
-        playbackStates.add(MediaPlayBackState.Stall);
+        List<MediaPlaybackState> playbackStates = new ArrayList<>();
+        playbackStates.add(MediaPlaybackState.Init);
+        playbackStates.add(MediaPlaybackState.Play);
+        playbackStates.add(MediaPlaybackState.Pause);
+        playbackStates.add(MediaPlaybackState.Seek);
+        playbackStates.add(MediaPlaybackState.Buffer);
+        playbackStates.add(MediaPlaybackState.Stall);
 
-        for (MediaPlayBackState state : playbackStates) {
+        for (MediaPlaybackState state : playbackStates) {
             String actual = hitGenerator.getMediaCollectionEvent(state);
             String expected = playBackStateToMediaCollectionEventMap.get(state);
             assertEquals(expected, actual);

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaContextTests.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaContextTests.java
@@ -143,79 +143,79 @@ public class MediaContextTests {
 
     @Test
     public void test_BufferState_setOnMediaContext() {
-        MediaPlayBackState state = MediaPlayBackState.Buffer;
+        MediaPlaybackState state = MediaPlaybackState.Buffer;
 
-        assertFalse(mediaContext.isInState(MediaPlayBackState.Buffer));
+        assertFalse(mediaContext.isInState(MediaPlaybackState.Buffer));
 
         mediaContext.enterState(state);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Buffer));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Buffer));
 
         mediaContext.exitState(state);
 
-        assertFalse(mediaContext.isInState(MediaPlayBackState.Buffer));
+        assertFalse(mediaContext.isInState(MediaPlaybackState.Buffer));
     }
 
     @Test
     public void test_SeekState_setOnMediaContext() {
-        MediaPlayBackState state = MediaPlayBackState.Seek;
+        MediaPlaybackState state = MediaPlaybackState.Seek;
 
-        assertFalse(mediaContext.isInState(MediaPlayBackState.Seek));
+        assertFalse(mediaContext.isInState(MediaPlaybackState.Seek));
 
         mediaContext.enterState(state);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Seek));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Seek));
 
         mediaContext.exitState(state);
 
-        assertFalse(mediaContext.isInState(MediaPlayBackState.Seek));
+        assertFalse(mediaContext.isInState(MediaPlaybackState.Seek));
     }
 
     @Test
     public void test_PlayState_setOnMediaContext() {
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Init));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Init));
 
-        mediaContext.enterState(MediaPlayBackState.Pause);
+        mediaContext.enterState(MediaPlaybackState.Pause);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Pause));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Pause));
 
-        mediaContext.enterState(MediaPlayBackState.Play);
+        mediaContext.enterState(MediaPlaybackState.Play);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Play));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Play));
 
-        mediaContext.enterState(MediaPlayBackState.Stall);
+        mediaContext.enterState(MediaPlaybackState.Stall);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Stall));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Stall));
 
         // Never enter idle state again
-        mediaContext.enterState(MediaPlayBackState.Init);
+        mediaContext.enterState(MediaPlaybackState.Init);
 
-        assertTrue(mediaContext.isInState(MediaPlayBackState.Stall));
+        assertTrue(mediaContext.isInState(MediaPlaybackState.Stall));
     }
 
     @Test
     public void test_IdleState_setOnMediaContext() {
         assertTrue(mediaContext.isIdle());
 
-        mediaContext.enterState(MediaPlayBackState.Buffer);
+        mediaContext.enterState(MediaPlaybackState.Buffer);
 
         assertTrue(mediaContext.isIdle());
 
-        mediaContext.enterState(MediaPlayBackState.Seek);
+        mediaContext.enterState(MediaPlaybackState.Seek);
 
         assertTrue(mediaContext.isIdle());
 
-        mediaContext.enterState(MediaPlayBackState.Pause);
+        mediaContext.enterState(MediaPlaybackState.Pause);
 
         assertTrue(mediaContext.isIdle());
 
-        mediaContext.enterState(MediaPlayBackState.Stall);
+        mediaContext.enterState(MediaPlaybackState.Stall);
 
         assertTrue(mediaContext.isIdle());
 
-        mediaContext.enterState(MediaPlayBackState.Play);
-        mediaContext.exitState(MediaPlayBackState.Seek);
-        mediaContext.exitState(MediaPlayBackState.Buffer);
+        mediaContext.enterState(MediaPlaybackState.Play);
+        mediaContext.exitState(MediaPlaybackState.Seek);
+        mediaContext.exitState(MediaPlaybackState.Buffer);
         assertFalse(mediaContext.isIdle());
     }
 
@@ -223,16 +223,16 @@ public class MediaContextTests {
     public void test_stateInfo_simpleStateTracking() {
         StateInfo stateInfo = StateInfo.create("myCustomState");
 
-        assertFalse(mediaContext.isInState(stateInfo));
+        assertFalse(mediaContext.isInPlayerState(stateInfo));
         assertFalse(mediaContext.hasTrackedState(stateInfo));
 
         assertTrue(mediaContext.startState(stateInfo));
-        assertTrue(mediaContext.isInState(stateInfo));
+        assertTrue(mediaContext.isInPlayerState(stateInfo));
 
         assertFalse(mediaContext.startState(stateInfo));
         assertTrue(mediaContext.endState(stateInfo));
 
-        assertFalse(mediaContext.isInState(stateInfo));
+        assertFalse(mediaContext.isInPlayerState(stateInfo));
         assertTrue(mediaContext.hasTrackedState(stateInfo));
         assertFalse(mediaContext.endState(stateInfo));
     }
@@ -242,11 +242,11 @@ public class MediaContextTests {
         StateInfo stateInfo = StateInfo.create("myCustomState");
 
         assertFalse(mediaContext.endState(stateInfo));
-        assertFalse(mediaContext.isInState(stateInfo));
+        assertFalse(mediaContext.isInPlayerState(stateInfo));
         assertFalse(mediaContext.hasTrackedState(stateInfo));
 
         assertTrue(mediaContext.startState(stateInfo));
-        assertTrue(mediaContext.isInState(stateInfo));
+        assertTrue(mediaContext.isInPlayerState(stateInfo));
 
         assertTrue(mediaContext.endState(stateInfo));
         assertTrue(mediaContext.hasTrackedState(stateInfo));
@@ -257,12 +257,12 @@ public class MediaContextTests {
         for (int i = 0; i < MediaTestConstants.EventDataKeys.StateInfo.STATE_LIMIT; i++) {
             StateInfo stateInfo = StateInfo.create(Integer.toString(i));
             assertTrue(mediaContext.startState(stateInfo));
-            assertTrue(mediaContext.isInState(stateInfo));
+            assertTrue(mediaContext.isInPlayerState(stateInfo));
         }
 
         StateInfo stateInfo = StateInfo.create("myCustomState");
         assertFalse(mediaContext.startState(stateInfo));
-        assertFalse(mediaContext.isInState(stateInfo));
+        assertFalse(mediaContext.isInPlayerState(stateInfo));
     }
 
     @Test
@@ -270,22 +270,22 @@ public class MediaContextTests {
         for (int i = 0; i < MediaTestConstants.EventDataKeys.StateInfo.STATE_LIMIT; i++) {
             StateInfo stateInfo = StateInfo.create(Integer.toString(i));
             assertTrue(mediaContext.startState(stateInfo));
-            assertTrue(mediaContext.isInState(stateInfo));
+            assertTrue(mediaContext.isInPlayerState(stateInfo));
         }
 
         assertTrue(mediaContext.hasReachedStateLimit());
 
         StateInfo stateInfo = StateInfo.create("myCustomState");
         assertFalse(mediaContext.startState(stateInfo));
-        assertFalse(mediaContext.isInState(stateInfo));
+        assertFalse(mediaContext.isInPlayerState(stateInfo));
 
         StateInfo stateInfo1 = StateInfo.create("0");
 
-        assertTrue(mediaContext.isInState(stateInfo1));
+        assertTrue(mediaContext.isInPlayerState(stateInfo1));
         assertTrue(mediaContext.endState(stateInfo1));
-        assertFalse(mediaContext.isInState(stateInfo1));
+        assertFalse(mediaContext.isInPlayerState(stateInfo1));
         assertTrue(mediaContext.startState(stateInfo1));
-        assertTrue(mediaContext.isInState(stateInfo1));
+        assertTrue(mediaContext.isInPlayerState(stateInfo1));
         assertTrue(mediaContext.hasTrackedState(stateInfo1));
     }
 
@@ -295,25 +295,25 @@ public class MediaContextTests {
         for (int i = 0; i < MediaTestConstants.EventDataKeys.StateInfo.STATE_LIMIT; i++) {
             StateInfo stateInfo = StateInfo.create(Integer.toString(i));
             assertTrue(mediaContext.startState(stateInfo));
-            assertTrue(mediaContext.isInState(stateInfo));
+            assertTrue(mediaContext.isInPlayerState(stateInfo));
         }
 
         assertTrue(mediaContext.hasReachedStateLimit());
 
         StateInfo newStateInfo = StateInfo.create("myCustomState");
         assertFalse(mediaContext.startState(newStateInfo));
-        assertFalse(mediaContext.isInState(newStateInfo));
+        assertFalse(mediaContext.isInPlayerState(newStateInfo));
 
         for (int i = 9; i >= 0; i--) {
             StateInfo stateInfo = StateInfo.create(Integer.toString(i));
             assertTrue(mediaContext.endState(stateInfo));
-            assertFalse(mediaContext.isInState(stateInfo));
+            assertFalse(mediaContext.isInPlayerState(stateInfo));
         }
 
         assertTrue(mediaContext.hasReachedStateLimit());
 
         assertFalse(mediaContext.startState(newStateInfo));
-        assertFalse(mediaContext.isInState(newStateInfo));
+        assertFalse(mediaContext.isInPlayerState(newStateInfo));
     }
 
     @Test
@@ -321,7 +321,7 @@ public class MediaContextTests {
         for (int i = 0; i < MediaTestConstants.EventDataKeys.StateInfo.STATE_LIMIT; i++) {
             StateInfo stateInfo = StateInfo.create(Integer.toString(i));
             assertTrue(mediaContext.startState(stateInfo));
-            assertTrue(mediaContext.isInState(stateInfo));
+            assertTrue(mediaContext.isInPlayerState(stateInfo));
         }
 
         assertTrue(mediaContext.hasReachedStateLimit());
@@ -330,12 +330,12 @@ public class MediaContextTests {
 
         StateInfo stateInfo = StateInfo.create("myCustomState");
         assertTrue(mediaContext.startState(stateInfo));
-        assertTrue(mediaContext.isInState(stateInfo));
+        assertTrue(mediaContext.isInPlayerState(stateInfo));
 
         StateInfo stateInfo1 = StateInfo.create("0");
 
         assertTrue(mediaContext.startState(stateInfo1));
-        assertTrue(mediaContext.isInState(stateInfo1));
+        assertTrue(mediaContext.isInPlayerState(stateInfo1));
     }
 
     @Test

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessorTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaEventProcessorTests.kt
@@ -26,7 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.util.*
 
@@ -280,6 +279,6 @@ class MediaEventProcessorTests {
             "edgemedia.appVersion" to "testAppVersion"
         )
         mediaEventProcessor.updateMediaState(stateUpdate)
-        verify(mockState, times(1)).updateState(eq(stateUpdate))
+        verify(mockState).updateState(eq(stateUpdate))
     }
 }

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGeneratorTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaXDMEventGeneratorTests.kt
@@ -1,0 +1,792 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.media.internal
+
+import com.adobe.marketing.mobile.edge.media.MediaConstants
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMCustomMetadata
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaCollection
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEvent
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaEventType
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMMediaSchema
+import com.adobe.marketing.mobile.edge.media.internal.xdm.XDMPlayerStateData
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import java.util.Date
+
+class MediaXDMEventGeneratorTests {
+    private lateinit var mediaInfo: MediaInfo
+    private lateinit var metadata: Map<String, String>
+    private lateinit var mediaContext: MediaContext
+    private lateinit var mockEventProcessor: MediaEventProcessor
+    private lateinit var eventGenerator: MediaXDMEventGenerator
+    private var currSessionId = 0
+    private var mockTimestamp = 0L
+    private var mockPlayhead = 0L
+
+    @Captor
+    private lateinit var eventCaptor: ArgumentCaptor<XDMMediaEvent>
+
+    @Captor
+    private lateinit var sessionIdCaptor: ArgumentCaptor<String>
+    private fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()
+
+    @Before
+    fun setup() {
+        eventCaptor = ArgumentCaptor.forClass(XDMMediaEvent::class.java)
+        sessionIdCaptor = ArgumentCaptor.forClass(String::class.java)
+        mediaInfo = MediaInfo.create("id", "name", "vod", MediaType.Video, 60.0)
+        metadata = mapOf("k1" to "v1", MediaConstants.VideoMetadataKeys.SHOW to "show")
+        mediaContext = MediaContext(mediaInfo, metadata)
+        mockEventProcessor = Mockito.mock(MediaEventProcessor::class.java)
+        Mockito.`when`(mockEventProcessor.createSession()).thenReturn((currSessionId++).toString())
+        eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, mapOf(), 0)
+    }
+
+    @Test
+    fun testProcessSessionStart() {
+        // setup
+        val sessionDetails = MediaXDMEventHelper.generateSessionDetails(mediaInfo, metadata)
+        sessionDetails.show = "show"
+
+        val customMetadata = listOf(XDMCustomMetadata("k1", "v1"))
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.sessionDetails = sessionDetails
+        mediaCollection.customMetadata = customMetadata
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.SESSION_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processSessionStart()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessSessionComplete() {
+        // setup
+        updateTs(10, reset = true)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.SESSION_COMPLETE, getDateFormattedTimestampFor(10), mediaCollection))
+
+        // test
+        eventGenerator.processSessionComplete()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessSessionEnd() {
+        // setup
+        updateTs(10, reset = true)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.SESSION_END, getDateFormattedTimestampFor(10), mediaCollection))
+
+        // test
+        eventGenerator.processSessionEnd()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdBreakStart() {
+        // setup
+        val adBreakInfo = AdBreakInfo.create("adBreak", 1, 2.0)
+        mediaContext.adBreakInfo = adBreakInfo
+        val adBreakDetails = MediaXDMEventHelper.generateAdvertisingPodDetails(adBreakInfo)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.advertisingPodDetails = adBreakDetails
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_BREAK_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdBreakStart()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdBreakSkip() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_BREAK_COMPLETE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdBreakComplete()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdBreakComplete() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_BREAK_COMPLETE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdBreakComplete()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdStart() {
+        // setup
+        val adInfo = AdInfo.create("id", "ad", 1, 15.0)
+        val metadata = mapOf(MediaConstants.AdMetadataKeys.SITE_ID to "testSiteID", "k1" to "v1")
+        mediaContext.setAdInfo(adInfo, metadata)
+
+        val adDetails = MediaXDMEventHelper.generateAdvertisingDetails(adInfo, metadata)
+        val adMetadata = MediaXDMEventHelper.generateAdCustomMetadata(metadata)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.advertisingDetails = adDetails
+        mediaCollection.customMetadata = adMetadata
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdStart()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdSkip() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_SKIP, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdSkip()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessAdComplete() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.AD_COMPLETE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processAdComplete()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessChapterStart() {
+        // setup
+        val chapterInfo = ChapterInfo.create("chapter", 1, 15.0, 30.0)
+        val metadata = mapOf("k1" to "v1")
+        mediaContext.setChapterInfo(chapterInfo, metadata)
+
+        val chapterDetails = MediaXDMEventHelper.generateChapterDetails(chapterInfo)
+        val chapterMetadata = MediaXDMEventHelper.generateChapterMetadata(metadata)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.chapterDetails = chapterDetails
+        mediaCollection.customMetadata = chapterMetadata
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.CHAPTER_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processChapterStart()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessChapterSkip() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.CHAPTER_SKIP, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processChapterSkip()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessChapterComplete() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.CHAPTER_COMPLETE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processChapterComplete()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessSessionAbort() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.SESSION_END, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processSessionAbort()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessSessionRestart() {
+        // setup
+        val sessionDetails = MediaXDMEventHelper.generateSessionDetails(mediaInfo, metadata, forceResume = true)
+        sessionDetails.show = "show"
+
+        val customMetadata = listOf(XDMCustomMetadata("k1", "v1"))
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.sessionDetails = sessionDetails
+        mediaCollection.customMetadata = customMetadata
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.SESSION_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processSessionRestart()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessBitrateChange() {
+        // setup
+        val qoeInfo = QoEInfo.create(1234.5, 12.3, 123.4, 1.2)
+        mediaContext.qoEInfo = qoeInfo
+
+        val qoeDetails = MediaXDMEventHelper.generateQoEDataDetails(qoeInfo)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.qoeDataDetails = qoeDetails
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.BITRATE_CHANGE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processBitrateChange()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessError() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.errorDetails = MediaXDMEventHelper.generateErrorDetails("errorID")
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.ERROR, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processError("errorID")
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessPlaybackPlay() {
+        // setup
+        mediaContext.enterState(MediaPlaybackState.Play)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PLAY, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processPlayback()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessPlaybackPause() {
+        // setup
+        mediaContext.enterState(MediaPlaybackState.Pause)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PAUSE_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processPlayback()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessPlaybackSeek() {
+        // setup
+        mediaContext.enterState(MediaPlaybackState.Seek)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PAUSE_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processPlayback()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessPlaybackBuffer() {
+        // setup
+        mediaContext.enterState(MediaPlaybackState.Buffer)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.BUFFER_START, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processPlayback()
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessPlaybackWithDoFlushSetToTrue() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processPlayback(doFlush = true)
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessStateStart() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.statesStart = listOf(XDMPlayerStateData(MediaConstants.PlayerState.FULLSCREEN))
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.STATES_UPDATE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processStateStart(StateInfo.create(MediaConstants.PlayerState.FULLSCREEN))
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testProcessStateEnd() {
+        // setup
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        mediaCollection.statesEnd = listOf(XDMPlayerStateData(MediaConstants.PlayerState.FULLSCREEN))
+
+        val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.STATES_UPDATE, getDateFormattedTimestampFor(0), mediaCollection))
+
+        // test
+        eventGenerator.processStateEnd(StateInfo.create(MediaConstants.PlayerState.FULLSCREEN))
+
+        // verify
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        val actualEvent = eventCaptor.value
+
+        assertEquals(expectedEvent, actualEvent)
+    }
+
+    @Test
+    fun testCustomMainPingInterval_validRange_sendsPingWithCustomValue() {
+        val validIntervals = listOf(10, 11, 22, 33, 44, 50)
+        for (interval in validIntervals) {
+            mockEventProcessor = Mockito.mock(MediaEventProcessor::class.java) // create new mock for each iteration
+
+            val internalMS = interval * 1000
+            val trackerConfig = mapOf<String, Any>(MediaConstants.TrackerConfig.MAIN_PING_INTERVAL to interval)
+            eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+            updateTs(internalMS, reset = true)
+
+            val mediaCollection = XDMMediaCollection()
+            mediaCollection.playhead = getPlayhead()
+            val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+            // test
+            eventGenerator.processPlayback()
+
+            // verify
+            verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+            val actualEvent = eventCaptor.value
+
+            assertEquals(expectedEvent, actualEvent)
+        }
+    }
+
+    @Test
+    fun testCustomMainPingInterval_invalidRange_sendsPingWithDefaultValue() {
+        val invalidIntervals = listOf(0, 1, 9, 51, 400)
+        for (interval in invalidIntervals) {
+            mockEventProcessor = Mockito.mock(MediaEventProcessor::class.java) // create new mock for each iteration
+
+            val trackerConfig = mapOf<String, Any>(MediaConstants.TrackerConfig.MAIN_PING_INTERVAL to interval)
+            eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+            updateTs(MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS, reset = true)
+
+            val mediaCollection = XDMMediaCollection()
+            mediaCollection.playhead = getPlayhead()
+            val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+            // test
+            eventGenerator.processPlayback()
+
+            // verify
+            verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+            val actualEvent = eventCaptor.value
+
+            assertEquals(expectedEvent, actualEvent)
+        }
+    }
+
+    @Test
+    fun testCustomAdPingInterval_validRange_sendsPingWithCustomValue() {
+        val validIntervals = listOf(1, 3, 9, 10)
+        for (interval in validIntervals) {
+            mockEventProcessor = Mockito.mock(MediaEventProcessor::class.java) // create new mock for each iteration
+
+            val internalMS = interval * 1000
+            val trackerConfig = mapOf<String, Any>(MediaConstants.TrackerConfig.AD_PING_INTERVAL to interval)
+            eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+            updateTs(internalMS, reset = true)
+            // mock adStart
+            mediaContext.setAdInfo(AdInfo.create("id", "ad", 1, 15.0), mapOf())
+
+            val mediaCollection = XDMMediaCollection()
+            mediaCollection.playhead = getPlayhead()
+            val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+            // test
+            eventGenerator.processPlayback()
+
+            // verify
+            verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+            val actualEvent = eventCaptor.value
+
+            assertEquals(expectedEvent, actualEvent)
+        }
+    }
+
+    @Test
+    fun testCustomAdPingInterval_invalidRange_sendsPingWithDefaultValue() {
+        val invalidIntervals = listOf(0, 11, 50, 400)
+        for (interval in invalidIntervals) {
+            mockEventProcessor = Mockito.mock(MediaEventProcessor::class.java) // create new mock for each iteration
+
+            val trackerConfig = mapOf<String, Any>(MediaConstants.TrackerConfig.AD_PING_INTERVAL to interval)
+            eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+            updateTs(MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS, reset = true)
+            // mock adStart
+            mediaContext.setAdInfo(AdInfo.create("id", "ad", 1, 15.0), mapOf())
+
+            val mediaCollection = XDMMediaCollection()
+            mediaCollection.playhead = getPlayhead()
+            val expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+            // test
+            eventGenerator.processPlayback()
+
+            // verify
+            verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+            val actualEvent = eventCaptor.value
+
+            assertEquals(expectedEvent, actualEvent)
+        }
+    }
+
+    @Test
+    fun testCustomMainPingIntervalAndCustomAdPingInterval_validRange_sendsPingWithCustomValue() {
+        // setup
+        val trackerConfig = mapOf<String, Any>(
+            MediaConstants.TrackerConfig.MAIN_PING_INTERVAL to 15,
+            MediaConstants.TrackerConfig.AD_PING_INTERVAL to 3
+        )
+        eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+
+        updateTs(15 * 1000)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        var expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test main content ping interval
+        eventGenerator.processPlayback()
+
+        // verify main content ping interval
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+
+        // mock adStart
+        mediaContext.setAdInfo(AdInfo.create("id", "ad", 1, 15.0), mapOf())
+        updateTs(3 * 1000)
+
+        mediaCollection.playhead = getPlayhead()
+        expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test ad content ping interval
+        eventGenerator.processPlayback()
+
+        // verify ad content ping interval
+        verify(mockEventProcessor, times(2)).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+    }
+
+    @Test
+    fun testDefaultMainPingIntervalAndCustomAdPingInterval() {
+        // setup
+        val trackerConfig = mapOf<String, Any>(
+            MediaConstants.TrackerConfig.AD_PING_INTERVAL to 3
+        )
+        eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+
+        updateTs(MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        var expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test main content ping interval
+        eventGenerator.processPlayback()
+
+        // verify main content ping interval
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+
+        // mock adStart
+        mediaContext.setAdInfo(AdInfo.create("id", "ad", 1, 15.0), mapOf())
+        updateTs(3 * 1000)
+
+        mediaCollection.playhead = getPlayhead()
+        expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test ad content ping interval
+        eventGenerator.processPlayback()
+
+        // verify ad content ping interval
+        verify(mockEventProcessor, times(2)).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+
+        // mock ad exit
+        mediaContext.clearAdInfo()
+        updateTs(MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS)
+        eventGenerator.processPlayback()
+
+        mediaCollection.playhead = getPlayhead()
+        expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // verify main content ping interval after exiting from ad
+        verify(mockEventProcessor, times(3)).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+    }
+
+    @Test
+    fun testCustomMainPingIntervalAndDefaultAdPingInterval() {
+        // setup
+        val trackerConfig = mapOf<String, Any>(
+            MediaConstants.TrackerConfig.MAIN_PING_INTERVAL to 15
+        )
+        eventGenerator = MediaXDMEventGenerator(mediaContext, mockEventProcessor, trackerConfig, 0)
+
+        updateTs(15 * 1000)
+
+        val mediaCollection = XDMMediaCollection()
+        mediaCollection.playhead = getPlayhead()
+        var expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test main content ping interval
+        eventGenerator.processPlayback()
+
+        // verify main content ping interval
+        verify(mockEventProcessor).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+
+        // mock adStart
+        mediaContext.setAdInfo(AdInfo.create("id", "ad", 1, 15.0), mapOf())
+        updateTs(MediaInternalConstants.PingInterval.REALTIME_TRACKING_MS)
+
+        mediaCollection.playhead = getPlayhead()
+        expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // test ad content ping interval
+        eventGenerator.processPlayback()
+
+        // verify ad content ping interval
+        verify(mockEventProcessor, times(2)).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+
+        // mock ad exit
+        mediaContext.clearAdInfo()
+        updateTs(15 * 1000)
+        eventGenerator.processPlayback()
+
+        mediaCollection.playhead = getPlayhead()
+        expectedEvent = XDMMediaEvent(XDMMediaSchema(XDMMediaEventType.PING, getDateFormattedTimestampFor(mockTimestamp), mediaCollection))
+
+        // verify main content ping interval after exiting from ad
+        verify(mockEventProcessor, times(3)).processEvent(capture(sessionIdCaptor), capture(eventCaptor))
+        assertEquals(expectedEvent, eventCaptor.value)
+    }
+
+    private fun updateTs(interval: Int, updatePlayhead: Boolean = true, reset: Boolean = false) {
+        if (reset) {
+            mockPlayhead = 0
+            mockTimestamp = 0
+        }
+        mockTimestamp += interval
+        if (updatePlayhead) {
+            mockPlayhead += (interval / 1000)
+            mediaContext.playhead = mockPlayhead.toDouble()
+        }
+
+        mediaContext.playhead = mockPlayhead.toDouble()
+        eventGenerator.setRefTS(mockTimestamp)
+    }
+
+    private fun getPlayhead(): Long {
+        return mediaContext.playhead.toLong()
+    }
+    private fun getDateFormattedTimestampFor(value: Long): Date {
+        return Date(value)
+    }
+}

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/xdm/XDMPropertyTests.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.media.internal.xdm
 
 import com.adobe.marketing.mobile.util.TimeUtils
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -227,6 +228,54 @@ class XDMPropertyTests {
 
         assertNotNull(xdm)
         assertTrue(xdm.isEmpty())
+    }
+
+    @Test
+    fun `XDMQoeDataDetails isValid all properties returns true`() {
+        val qoeDataDetails = XDMQoeDataDetails()
+        qoeDataDetails.bitrate = 128
+        qoeDataDetails.droppedFrames = 10
+        qoeDataDetails.framesPerSecond = 59
+        qoeDataDetails.timeToStart = 5
+
+        assertTrue(qoeDataDetails.isValid())
+    }
+
+    @Test
+    fun `XDMQoeDataDetails isValid missing properties returns false`() {
+        val qoeDataDetails1 = XDMQoeDataDetails()
+
+        assertFalse(qoeDataDetails1.isValid())
+
+        qoeDataDetails1.droppedFrames = 10
+        qoeDataDetails1.framesPerSecond = 59
+        qoeDataDetails1.timeToStart = 5
+
+        assertFalse(qoeDataDetails1.isValid())
+
+        val qoeDataDetails2 = XDMQoeDataDetails()
+
+        qoeDataDetails2.bitrate = 10
+        qoeDataDetails2.framesPerSecond = 59
+        qoeDataDetails2.timeToStart = 5
+
+        assertFalse(qoeDataDetails2.isValid())
+
+        val qoeDataDetails3 = XDMQoeDataDetails()
+
+        qoeDataDetails3.bitrate = 10
+        qoeDataDetails3.droppedFrames = 59
+        qoeDataDetails3.timeToStart = 5
+
+        assertFalse(qoeDataDetails3.isValid())
+
+        val qoeDataDetails4 = XDMQoeDataDetails()
+
+        qoeDataDetails4.bitrate = 10
+        qoeDataDetails4.droppedFrames = 59
+        qoeDataDetails4.framesPerSecond = 5
+
+        assertFalse(qoeDataDetails4.isValid())
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Implemented XDMEventGenerator class responsible for formatting and generating ping for public APIs and internal state of the session
- Added support for custom ping interval for main and ad content using tracker configuration
- Added Unit tests for XDMEventGenerator class and also the custom paing interval feature
- Refactored code and some cleanup
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
