### PR TITLE
Use EventType and EventSource from Core

### DIFF
--- a/code/edgemedia/build.gradle
+++ b/code/edgemedia/build.gradle
@@ -67,14 +67,11 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
     //noinspection GradleDependency
 
-    testImplementation 'org.json:json:20180813'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "com.adobe.marketing.mobile:edge:$mavenEdgeVersion"
     androidTestImplementation "com.adobe.marketing.mobile:edgeidentity:2.+"
-    androidTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.12.7"
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7'
-
 }
 
 tasks.withType(Test) {

--- a/code/edgemedia/src/androidTest/java/com/adobe/marketing/mobile/edge/media/internal/MediaEdgeIntegrationTests.kt
+++ b/code/edgemedia/src/androidTest/java/com/adobe/marketing/mobile/edge/media/internal/MediaEdgeIntegrationTests.kt
@@ -31,8 +31,7 @@ import com.adobe.marketing.mobile.util.FunctionalTestHelper.getAllNetworkRequest
 import com.adobe.marketing.mobile.util.FunctionalTestHelper.resetTestExpectations
 import com.adobe.marketing.mobile.util.FunctionalTestHelper.setExpectationEvent
 import com.adobe.marketing.mobile.util.FunctionalTestHelper.setNetworkResponseFor
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import com.adobe.marketing.mobile.util.JsonTestUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -409,8 +408,7 @@ class MediaEdgeIntegrationTests {
 
     private fun getXDMDataFromNetworkRequest(request: NetworkRequest): Map<String, Any> {
         val body = URLDecoder.decode(String(request.body), "UTF-8")
-        val requestBodyMap = ObjectMapper().readValue<MutableMap<Any, Any>>(body)
-
+        val requestBodyMap = JsonTestUtils.parseNetworkResponseAsMap(body) ?: return mapOf()
         val eventDataList = requestBodyMap["events"] as? List<Map<String, Any>> ?: return mapOf()
 
         val eventData = eventDataList[0]

--- a/code/edgemedia/src/androidTest/java/com/adobe/marketing/mobile/util/JsonTestUtils.java
+++ b/code/edgemedia/src/androidTest/java/com/adobe/marketing/mobile/util/JsonTestUtils.java
@@ -1,0 +1,30 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Map;
+
+public class JsonTestUtils {
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> parseNetworkResponseAsMap(String body) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return (Map<String, Object>) mapper.readValue(body, Map.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaExtension.java
@@ -74,13 +74,11 @@ public class MediaExtension extends Extension {
                         EventSource.REQUEST_RESET,
                         this::handleResetIdentities);
         getApi().registerEventListener(
-                        MediaInternalConstants.Media.EVENT_TYPE_EDGE_MEDIA,
-                        MediaInternalConstants.Media.EVENT_SOURCE_TRACKER_REQUEST,
+                        EventType.EDGE_MEDIA,
+                        EventSource.CREATE_TRACKER,
                         this::handleMediaTrackerRequestEvent);
         getApi().registerEventListener(
-                        MediaInternalConstants.Media.EVENT_TYPE_EDGE_MEDIA,
-                        MediaInternalConstants.Media.EVENT_SOURCE_TRACK_MEDIA,
-                        this::handleMediaTrackEvent);
+                        EventType.EDGE_MEDIA, EventSource.TRACK_MEDIA, this::handleMediaTrackEvent);
         getApi().registerEventListener(
                         EventType.EDGE,
                         MediaInternalConstants.Media.EVENT_SOURCE_MEDIA_EDGE_SESSION,

--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -19,10 +19,6 @@ final class MediaInternalConstants {
     private MediaInternalConstants() {}
 
     static final class Media {
-        // TODO - use EventType.EDGE_MEDIA when released
-        static final String EVENT_TYPE_EDGE_MEDIA = "com.adobe.eventType.edgeMedia";
-        static final String EVENT_SOURCE_TRACKER_REQUEST = "com.adobe.eventSource.createTracker";
-        static final String EVENT_SOURCE_TRACK_MEDIA = "com.adobe.eventSource.trackMedia";
         static final String EVENT_SOURCE_MEDIA_EDGE_SESSION = "media-analytics:new-session";
 
         private Media() {}

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/internal/MediaTrackerEventGenerator.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/internal/MediaTrackerEventGenerator.java
@@ -16,6 +16,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.edge.media.Media;
 import com.adobe.marketing.mobile.edge.media.MediaTracker;
 import com.adobe.marketing.mobile.services.Log;
@@ -84,8 +86,8 @@ public class MediaTrackerEventGenerator implements MediaTracker {
         Event event =
                 new Event.Builder(
                                 "Edge Media CreateTrackerRequest",
-                                MediaInternalConstants.Media.EVENT_TYPE_EDGE_MEDIA,
-                                MediaInternalConstants.Media.EVENT_SOURCE_TRACKER_REQUEST)
+                                EventType.EDGE_MEDIA,
+                                EventSource.CREATE_TRACKER)
                         .setEventData(eventData)
                         .build();
 
@@ -209,8 +211,8 @@ public class MediaTrackerEventGenerator implements MediaTracker {
         Event event =
                 new Event.Builder(
                                 "Edge Media TrackMedia",
-                                MediaInternalConstants.Media.EVENT_TYPE_EDGE_MEDIA,
-                                MediaInternalConstants.Media.EVENT_SOURCE_TRACK_MEDIA)
+                                EventType.EDGE_MEDIA,
+                                EventSource.TRACK_MEDIA)
                         .setEventData(eventData)
                         .build();
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -15,6 +15,6 @@ mavenRepoDescription=Adobe Experience Platform Edge Media extension for the Adob
 mavenUploadDryRunFlag=false
 
 # production versions for production build
-mavenCoreVersion=2.0.0
+mavenCoreVersion=2.2.0-SNAPSHOT
 mavenEdgeVersion=2.1.0
 androidxAnnotationVersion=1.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set Mobile Core dependency to `2.2.0-SNAPSHOT`.
Update local uses of `com.adobe.eventType.edgeMedia`, `com.adobe.eventSource.createTracker`, and `com.adobe.eventSource.trackMedia` to those in Core EventType and EventSource. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
