### PR TITLE
Use parameter name 'id' and QoE

### DIFF
--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -343,7 +343,7 @@ val mediaObject = Media.createMediaObject(
                         Media.MediaType.Video
                     )
 
-val mediaMetadata = HashMap<String, String>()
+val mediaMetadata = mutableMapOf<String, String>()
 // Standard metadata keys provided by adobe.
 mediaMetadata[MediaConstants.VideoMetadataKeys.EPISODE] = "Sample Episode" 
 mediaMetadata[MediaConstants.VideoMetadataKeys.SHOW] = "Sample Show"
@@ -475,23 +475,23 @@ public void trackEvent(Media.Event event, Map<String, Object> info, Map<String, 
 
 ```java
 // StateStart
-  HashMap<String, Object> stateObject = Media.createStateObject("fullscreen");
+  HashMap<String, Object> stateObject = Media.createStateObject(MediaConstants.PlayerState.FULLSCREEN);
   tracker.trackEvent(Media.Event.StateStart, stateObject, null);
 
 // StateEnd
-  HashMap<String, Object> stateObject = Media.createStateObject("fullscreen");
+  HashMap<String, Object> stateObject = Media.createStateObject(MediaConstants.PlayerState.FULLSCREEN);
   tracker.trackEvent(Media.Event.StateEnd, stateObject, null);
 ```
 
 ##### Kotlin
 ```kotlin
 // StateStart
-    val stateObject = Media.createStateObject("fullscreen")
+    val stateObject = Media.createStateObject(MediaConstants.PlayerState.FULLSCREEN)
     tracker.trackEvent(Media.Event.StateStart, stateObject, null)
 
 // StateEnd
-    val stateObject = Media.createStateObject("fullscreen")
-    tracker.trackEvent(Media.Event.StateEnd, stateObject, null)`
+    val stateObject = Media.createStateObject(MediaConstants.PlayerState.FULLSCREEN)
+    tracker.trackEvent(Media.Event.StateEnd, stateObject, null)
 ```
 
 
@@ -547,7 +547,7 @@ public void trackEvent(Media.Event event, Map<String, Object> info, Map<String, 
 //AdStart
     val adObject = Media.createAdObject("ad-name", "ad-id", 1, 15)
 
-    val adMetadata = HashMap<String, String>()
+    val adMetadata = mutableMapOf<String, String>()
     // Standard metadata keys provided by adobe.
     adMetadata[MediaConstants.AdMetadataKeys.ADVERTISER] = "Sample Advertiser"
     adMetadata[MediaConstants.AdMetadataKeys.CAMPAIGN_ID] = "Sample Campaign"
@@ -705,12 +705,12 @@ Provides the media tracker with the current QoE information. For accurate tracki
 
 | Parameter | Description |
 | :--- | :--- |
-| `qoeObject` | Current QoE information that was created by using the createQoEObject method. |
+| `qoeInfo` | Current QoE information that was created by using the createQoEObject method. |
 
 
 #### Syntax
 ```java
-public void updateQoEObject(Map<String, Object> qoeObject);
+public void updateQoEObject(Map<String, Object> qoeInfo);
 ```
 
 #### Example

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
@@ -128,7 +128,7 @@ public class Media {
      * @param startupTime The start up time of media in seconds
      * @param fps The current frames per second information
      * @param droppedFrames The number of dropped frames so far
-     * @return A MediaObject instance representing the QoEObject.
+     * @return A map representing quality of experience information.
      */
     @NonNull public static HashMap<String, Object> createQoEObject(
             final int bitrate, final int startupTime, final int fps, final int droppedFrames) {

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
@@ -122,13 +122,13 @@ public class Media {
     }
 
     /**
-     * Creates an instance of the QoS info object
+     * Creates an instance of the QoE info object
      *
      * @param bitrate The bitrate of media in bits per second
      * @param startupTime The start up time of media in seconds
      * @param fps The current frames per second information
      * @param droppedFrames The number of dropped frames so far
-     * @return A MediaObject instance representing the QoSObject.
+     * @return A MediaObject instance representing the QoEObject.
      */
     @NonNull public static HashMap<String, Object> createQoEObject(
             final int bitrate, final int startupTime, final int fps, final int droppedFrames) {

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/Media.java
@@ -61,7 +61,7 @@ public class Media {
      * Creates an instance of the video info object
      *
      * @param name The name of the media
-     * @param mediaId The unique identifier for the media
+     * @param id The unique identifier for the media
      * @param length The length of the media in seconds
      * @param streamType The stream type as a string. Use the pre-defined constants for vod, live,
      *     and linear content
@@ -70,11 +70,11 @@ public class Media {
      */
     @NonNull public static HashMap<String, Object> createMediaObject(
             @NonNull final String name,
-            @NonNull final String mediaId,
+            @NonNull final String id,
             final int length,
             @NonNull final String streamType,
             @NonNull final MediaType mediaType) {
-        return MediaObject.createMediaInfo(mediaId, name, streamType, mediaType, length);
+        return MediaObject.createMediaInfo(id, name, streamType, mediaType, length);
     }
 
     /**
@@ -94,17 +94,17 @@ public class Media {
      * Creates an instance of the Ad info object
      *
      * @param name The name of the ad
-     * @param adId The unique id for the ad
+     * @param id The unique id for the ad
      * @param position The start position of the ad
      * @param length The length of the ad in seconds
      * @return A MediaObject instance representing the Ad.
      */
     @NonNull public static HashMap<String, Object> createAdObject(
             @NonNull final String name,
-            @NonNull final String adId,
+            @NonNull final String id,
             final int position,
             final int length) {
-        return MediaObject.createAdInfo(name, adId, position, length);
+        return MediaObject.createAdInfo(name, id, position, length);
     }
 
     /**

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaTracker.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaTracker.java
@@ -65,11 +65,11 @@ public interface MediaTracker {
     /**
      * Method to update current QoE information.
      *
-     * @param qoeData the Map instance containing current QoE information. This method can be called
+     * @param qoeInfo the Map instance containing current QoE information. This method can be called
      *     multiple times during a playback session. Player implementation must always return the
      *     most recently available QoE data.
      */
-    void updateQoEObject(@NonNull Map<String, Object> qoeData);
+    void updateQoEObject(@NonNull Map<String, Object> qoeInfo);
 
     /**
      * Method to update current playhead.

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaTracker.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaTracker.java
@@ -63,11 +63,11 @@ public interface MediaTracker {
             @Nullable Map<String, String> contextData);
 
     /**
-     * Method to update current QoS information.
+     * Method to update current QoE information.
      *
-     * @param qoeData the Map instance containing current QoS information. This method can be called
+     * @param qoeData the Map instance containing current QoE information. This method can be called
      *     multiple times during a playback session. Player implementation must always return the
-     *     most recently available QoS data.
+     *     most recently available QoE data.
      */
     void updateQoEObject(@NonNull Map<String, Object> qoeData);
 

--- a/code/testapp/src/main/java/com/adobe/mediaanalyticstestapp/player/VideoPlayer.java
+++ b/code/testapp/src/main/java/com/adobe/mediaanalyticstestapp/player/VideoPlayer.java
@@ -56,7 +56,7 @@ public class VideoPlayer extends Observable {
 
     private AudioManager _audio;
 
-    private Map<String, Object> _adBreakInfo, _adInfo, _chapterInfo, _qosInfo;
+    private Map<String, Object> _adBreakInfo, _adInfo, _chapterInfo, _qoeInfo;
 
     private Clock _clock;
 
@@ -90,12 +90,12 @@ public class VideoPlayer extends Observable {
         _adInfo = null;
         _chapterInfo = null;
 
-        // Build a static/hard-coded QoS info here.
-        _qosInfo = new HashMap<String, Object>();
-        _qosInfo.put("bitrate", 50000);
-        _qosInfo.put("fps", 24);
-        _qosInfo.put("droppedFrames", 10);
-        _qosInfo.put("startupTime", 2);
+        // Build a static/hard-coded QoE info here.
+        _qoeInfo = new HashMap<String, Object>();
+        _qoeInfo.put("bitrate", 50000);
+        _qoeInfo.put("fps", 24);
+        _qoeInfo.put("droppedFrames", 10);
+        _qoeInfo.put("startupTime", 2);
 
         _clock = null;
     }
@@ -134,8 +134,8 @@ public class VideoPlayer extends Observable {
         return _chapterInfo;
     }
 
-    public Map<String, Object> getQoSInfo() {
-        return _qosInfo;
+    public Map<String, Object> getQoEInfo() {
+        return _qoeInfo;
     }
 
     public void loadContent(Uri uri) {

--- a/code/testappkotlin/src/main/java/com/adobe/media/testappkotlin/player/VideoPlayer.java
+++ b/code/testappkotlin/src/main/java/com/adobe/media/testappkotlin/player/VideoPlayer.java
@@ -56,7 +56,7 @@ public class VideoPlayer extends Observable {
 
     private AudioManager _audio;
 
-    private Map<String, Object> _adBreakInfo, _adInfo, _chapterInfo, _qosInfo;
+    private Map<String, Object> _adBreakInfo, _adInfo, _chapterInfo, _qoeInfo;
 
     private Clock _clock;
 
@@ -90,12 +90,12 @@ public class VideoPlayer extends Observable {
         _adInfo = null;
         _chapterInfo = null;
 
-        // Build a static/hard-coded QoS info here.
-        _qosInfo = new HashMap<String, Object>();
-        _qosInfo.put("bitrate", 50000);
-        _qosInfo.put("fps", 24);
-        _qosInfo.put("droppedFrames", 10);
-        _qosInfo.put("startupTime", 2);
+        // Build a static/hard-coded QoE info here.
+        _qoeInfo = new HashMap<String, Object>();
+        _qoeInfo.put("bitrate", 50000);
+        _qoeInfo.put("fps", 24);
+        _qoeInfo.put("droppedFrames", 10);
+        _qoeInfo.put("startupTime", 2);
 
         _clock = null;
     }
@@ -134,8 +134,8 @@ public class VideoPlayer extends Observable {
         return _chapterInfo;
     }
 
-    public Map<String, Object> getQoSInfo() {
-        return _qosInfo;
+    public Map<String, Object> getQoEInfo() {
+        return _qoeInfo;
     }
 
     public void loadContent(Uri uri) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change public API parameters names `mediaId` and `adId` to just `id`.
Change all instances of QoS to QoE.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
