### PR TITLE
Use 'a.media.' prefix to public metadata key names

### DIFF
--- a/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
+++ b/code/edgemedia/src/main/java/com/adobe/marketing/mobile/edge/media/internal/MediaInternalConstants.java
@@ -160,45 +160,6 @@ final class MediaInternalConstants {
 
             private MediaEventName() {}
         }
-
-        static final class StandardMediaMetadata {
-            static final String SHOW = "a.media.show";
-            static final String SEASON = "a.media.season";
-            static final String EPISODE = "a.media.episode";
-            static final String ASSET_ID = "a.media.asset";
-            static final String GENRE = "a.media.genre";
-            static final String FIRST_AIR_DATE = "a.media.airDate";
-            static final String FIRST_DIGITAL_DATE = "a.media.digitalDate";
-            static final String RATING = "a.media.rating";
-            static final String ORIGINATOR = "a.media.originator";
-            static final String NETWORK = "a.media.network";
-            static final String SHOW_TYPE = "a.media.type";
-            static final String AD_LOAD = "a.media.adLoad";
-            static final String MVPD = "a.media.pass.mvpd";
-            static final String AUTH = "a.media.pass.auth";
-            static final String DAY_PART = "a.media.dayPart";
-            static final String FEED = "a.media.feed";
-            static final String STREAM_FORMAT = "a.media.format";
-            static final String ARTIST = "a.media.artist";
-            static final String ALBUM = "a.media.album";
-            static final String LABEL = "a.media.label";
-            static final String AUTHOR = "a.media.author";
-            static final String STATION = "a.media.station";
-            static final String PUBLISHER = "a.media.publisher";
-
-            private StandardMediaMetadata() {}
-        }
-
-        static final class StandardAdMetadata {
-            static final String ADVERTISER = "a.media.ad.advertiser";
-            static final String CAMPAIGN_ID = "a.media.ad.campaign";
-            static final String CREATIVE_ID = "a.media.ad.creative";
-            static final String PLACEMENT_ID = "a.media.ad.placement";
-            static final String SITE_ID = "a.media.ad.site";
-            static final String CREATIVE_URL = "a.media.ad.creativeURL";
-
-            private StandardAdMetadata() {}
-        }
     }
 
     static final class ErrorSource {

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
@@ -42,7 +42,7 @@ public class MediaConstants {
 
     /** These constant strings define standard audio metadata keys. */
     public static final class AudioMetadataKeys {
-        public static final String ALBUM = "mediaCollection.sessionDetails.album";
+        public static final String ALBUM = "a.media.album";
         public static final String ARTIST = "a.media.artist";
         public static final String AUTHOR = "a.media.author";
         public static final String LABEL = "a.media.label";

--- a/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
+++ b/code/edgemedia/src/phone/java/com/adobe/marketing/mobile/edge/media/MediaConstants.java
@@ -30,47 +30,47 @@ public class MediaConstants {
 
     /** These constant strings define standard ad metadata keys. */
     public static final class AdMetadataKeys {
-        public static final String ADVERTISER = "advertiser";
-        public static final String CAMPAIGN_ID = "campaignID";
-        public static final String CREATIVE_ID = "creativeID";
-        public static final String CREATIVE_URL = "creativeURL";
-        public static final String PLACEMENT_ID = "placementID";
-        public static final String SITE_ID = "siteID";
+        public static final String ADVERTISER = "a.media.ad.advertiser";
+        public static final String CAMPAIGN_ID = "a.media.ad.campaign";
+        public static final String CREATIVE_ID = "a.media.ad.creative";
+        public static final String CREATIVE_URL = "a.media.ad.creativeURL";
+        public static final String PLACEMENT_ID = "a.media.ad.placement";
+        public static final String SITE_ID = "a.media.ad.site";
 
         private AdMetadataKeys() {}
     }
 
     /** These constant strings define standard audio metadata keys. */
     public static final class AudioMetadataKeys {
-        public static final String ALBUM = "album";
-        public static final String ARTIST = "artist";
-        public static final String AUTHOR = "author";
-        public static final String LABEL = "label";
-        public static final String PUBLISHER = "publisher";
-        public static final String STATION = "station";
+        public static final String ALBUM = "mediaCollection.sessionDetails.album";
+        public static final String ARTIST = "a.media.artist";
+        public static final String AUTHOR = "a.media.author";
+        public static final String LABEL = "a.media.label";
+        public static final String PUBLISHER = "a.media.publisher";
+        public static final String STATION = "a.media.station";
 
         private AudioMetadataKeys() {}
     }
 
     /** These constant strings define standard video metadata keys. */
     public static final class VideoMetadataKeys {
-        public static final String AD_LOAD = "adLoad";
-        public static final String ASSET_ID = "assetID";
-        public static final String AUTHORIZED = "isAuthenticated";
-        public static final String DAY_PART = "dayPart";
-        public static final String EPISODE = "episode";
-        public static final String FEED = "feed";
-        public static final String FIRST_AIR_DATE = "firstAirDate";
-        public static final String FIRST_DIGITAL_DATE = "firstDigitalDate";
-        public static final String GENRE = "genre";
-        public static final String MVPD = "mvpd";
-        public static final String NETWORK = "network";
-        public static final String ORIGINATOR = "originator";
-        public static final String SEASON = "season";
-        public static final String SHOW = "show";
-        public static final String SHOW_TYPE = "showType";
-        public static final String STREAM_FORMAT = "streamFormat";
-        public static final String RATING = "rating";
+        public static final String AD_LOAD = "a.media.adLoad";
+        public static final String ASSET_ID = "a.media.asset";
+        public static final String AUTHORIZED = "a.media.pass.auth";
+        public static final String DAY_PART = "a.media.dayPart";
+        public static final String EPISODE = "a.media.episode";
+        public static final String FEED = "a.media.feed";
+        public static final String FIRST_AIR_DATE = "a.media.airDate";
+        public static final String FIRST_DIGITAL_DATE = "a.media.digitalDate";
+        public static final String GENRE = "a.media.genre";
+        public static final String MVPD = "a.media.pass.mvpd";
+        public static final String NETWORK = "a.media.network";
+        public static final String ORIGINATOR = "a.media.originator";
+        public static final String RATING = "a.media.rating";
+        public static final String SEASON = "a.media.season";
+        public static final String SHOW = "a.media.show";
+        public static final String SHOW_TYPE = "a.media.type";
+        public static final String STREAM_FORMAT = "a.media.format";
 
         private VideoMetadataKeys() {}
     }

--- a/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaTestConstants.java
+++ b/code/edgemedia/src/test/java/com/adobe/marketing/mobile/edge/media/internal/MediaTestConstants.java
@@ -160,44 +160,5 @@ public final class MediaTestConstants {
 
             private MediaEventName() {}
         }
-
-        static final class StandardMediaMetadata {
-            static final String SHOW = "a.media.show";
-            static final String SEASON = "a.media.season";
-            static final String EPISODE = "a.media.episode";
-            static final String ASSET_ID = "a.media.asset";
-            static final String GENRE = "a.media.genre";
-            static final String FIRST_AIR_DATE = "a.media.airDate";
-            static final String FIRST_DIGITAL_DATE = "a.media.digitalDate";
-            static final String RATING = "a.media.rating";
-            static final String ORIGINATOR = "a.media.originator";
-            static final String NETWORK = "a.media.network";
-            static final String SHOW_TYPE = "a.media.type";
-            static final String AD_LOAD = "a.media.adLoad";
-            static final String MVPD = "a.media.pass.mvpd";
-            static final String AUTH = "a.media.pass.auth";
-            static final String DAY_PART = "a.media.dayPart";
-            static final String FEED = "a.media.feed";
-            static final String STREAM_FORMAT = "a.media.format";
-            static final String ARTIST = "a.media.artist";
-            static final String ALBUM = "a.media.album";
-            static final String LABEL = "a.media.label";
-            static final String AUTHOR = "a.media.author";
-            static final String STATION = "a.media.station";
-            static final String PUBLISHER = "a.media.publisher";
-
-            private StandardMediaMetadata() {}
-        }
-
-        static final class StandardAdMetadata {
-            static final String ADVERTISER = "a.media.ad.advertiser";
-            static final String CAMPAIGN_ID = "a.media.ad.campaign";
-            static final String CREATIVE_ID = "a.media.ad.creative";
-            static final String PLACEMENT_ID = "a.media.ad.placement";
-            static final String SITE_ID = "a.media.ad.site";
-            static final String CREATIVE_URL = "a.media.ad.creativeURL";
-
-            private StandardAdMetadata() {}
-        }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add "a.media." prefix in public keys for `AdMetadata`, `AudioMetadata`, and `VideoMetadata` to prevent conflicts with any customer's custom key names. This essentially brings back the original key names used in the Media extension.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
